### PR TITLE
Stub out the FastCGI API

### DIFF
--- a/Sources/KituraNIO/FastCGI/FastCGI.swift
+++ b/Sources/KituraNIO/FastCGI/FastCGI.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// The "root" class for the FastCGI server implementation.
+public class FastCGI {
+ 
+    //
+    // Global Constants used through FastCGI protocol implementation
+    //
+    struct Constants {
+        
+        // general
+        //
+        static let FASTCGI_PROTOCOL_VERSION : UInt8 = 1
+        static let FASTCGI_DEFAULT_REQUEST_ID : UInt16 = 0
+        
+        // FastCGI record types
+        //
+        static let FCGI_NO_TYPE : UInt8 = 0
+        static let FCGI_BEGIN_REQUEST : UInt8 = 1
+        static let FCGI_END_REQUEST : UInt8 = 3
+        static let FCGI_PARAMS : UInt8 = 4
+        static let FCGI_STDIN : UInt8 = 5
+        static let FCGI_STDOUT : UInt8 = 6
+        
+        // sub types
+        //
+        static let FCGI_SUBTYPE_NO_TYPE : UInt8 = 99
+        static let FCGI_REQUEST_COMPLETE : UInt8 = 0
+        static let FCGI_CANT_MPX_CONN : UInt8 = 1
+        static let FCGI_UNKNOWN_ROLE : UInt8 = 3
+        
+        // roles
+        //
+        static let FCGI_NO_ROLE : UInt16 = 99
+        static let FCGI_RESPONDER : UInt16 = 1
+        
+        // flags
+        //
+        static let FCGI_KEEP_CONN : UInt8 = 1
+        
+        // request headers of note
+        // we translate these into internal variables
+        //
+        static let HEADER_REQUEST_METHOD : String = "REQUEST_METHOD";
+        static let HEADER_REQUEST_SCHEME : String = "REQUEST_SCHEME";
+        static let HEADER_HTTP_HOST : String = "HTTP_HOST";
+        static let HEADER_REQUEST_URI : String = "REQUEST_URI";
+    }
+    
+    //
+    // Exceptions
+    //
+    enum RecordErrors : Swift.Error {
+        
+        case invalidType
+        case invalidSubType
+        case invalidRequestId
+        case invalidRole
+        case oversizeData
+        case invalidVersion
+        case emptyParameters
+        case bufferExhausted
+        case unsupportedRole
+        case internalError
+        case protocolError
+    }
+
+    /// Create a `FastCGIServer` instance.
+    /// Provided as a convenience and for consistency
+    /// with the HTTP implementation.
+    ///
+    /// - Returns: A `FastCGIServer` instance.
+    public static func createServer() -> FastCGIServer {
+        return FastCGIServer()
+    }
+
+    
+}

--- a/Sources/KituraNIO/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNIO/FastCGI/FastCGIServer.swift
@@ -1,0 +1,135 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Dispatch
+import LoggerAPI
+
+/// A server that listens for incoming HTTP requests that are sent using the FastCGI
+/// protocol.
+public class FastCGIServer: Server {
+
+    public typealias ServerType = FastCGIServer
+
+    /// The `ServerDelegate` to handle incoming requests.
+    public var delegate: ServerDelegate?
+
+    /// Port number for listening for new connections
+    public private(set) var port: Int?
+
+    /// A server state.
+    public private(set) var state: ServerState = .unknown
+
+    /// Retrieve an appropriate connection backlog value for our listen socket.
+    /// This log is taken from Nginx, and tests out with good results.
+    private lazy var maxPendingConnections: Int = {
+        #if os(Linux)
+            return 511
+        #else
+            return -1
+        #endif
+    }()
+
+    /// Whether or not this server allows port reuse (default: disallowed)
+    public var allowPortReuse: Bool = false
+
+    fileprivate let lifecycleListener = ServerLifecycleListener()
+
+    public init() {
+    }
+
+    /// Listens for connections on a socket
+    ///
+    /// - Parameter on: port number for new connections
+    public func listen(on port: Int) throws {
+        fatalError("FastCGI is not implemented yet.")
+    }
+
+    /// Static method to create a new `FastCGIServer` and have it listen for conenctions
+    ///
+    /// - Parameter on: port number for accepting new connections
+    /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
+    ///
+    /// - Returns: a new `FastCGIServer` instance
+    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> FastCGIServer {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Listens for connections on a socket
+    ///
+    /// - Parameter port: port number for new connections (ex. 9000)
+    /// - Parameter errorHandler: optional callback for error handling
+    @available(*, deprecated, message: "use 'listen(on:) throws' with 'server.failed(callback:)' instead")
+    public func listen(port: Int, errorHandler: ((Swift.Error) -> Void)? = nil) {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Static method to create a new `FastCGIServer` and have it listen for conenctions
+    ///
+    /// - Parameter port: port number for accepting new connections
+    /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
+    /// - Parameter errorHandler: optional callback for error handling
+    ///
+    /// - Returns: a new `FastCGIServer` instance
+    @available(*, deprecated, message: "use 'listen(on:delegate:) throws' with 'server.failed(callback:)' instead")
+    public static func listen(port: Int, delegate: ServerDelegate, errorHandler: ((Swift.Error) -> Void)? = nil) -> FastCGIServer {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Stop listening for new connections.
+    public func stop() {
+        fatalError("FastCGI is not implemented yet.")
+    }
+
+    /// Add a new listener for server being started
+    ///
+    /// - Parameter callback: The listener callback that will run on server successfull start-up
+    ///
+    /// - Returns: a `FastCGIServer` instance
+    @discardableResult
+    public func started(callback: @escaping () -> Void) -> Self {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Add a new listener for server being stopped
+    ///
+    /// - Parameter callback: The listener callback that will run when server stops
+    ///
+    /// - Returns: a `FastCGIServer` instance
+    @discardableResult
+    public func stopped(callback: @escaping () -> Void) -> Self {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Add a new listener for server throwing an error
+    ///
+    /// - Parameter callback: The listener callback that will run when server throws an error
+    ///
+    /// - Returns: a `FastCGIServer` instance
+    @discardableResult
+    public func failed(callback: @escaping (Swift.Error) -> Void) -> Self {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Add a new listener for when listenSocket.acceptClientConnection throws an error
+    ///
+    /// - Parameter callback: The listener callback that will run
+    ///
+    /// - Returns: a Server instance
+    @discardableResult
+    public func clientConnectionFailed(callback: @escaping (Swift.Error) -> Void) -> Self {
+        fatalError("FastCGI not implemented yet.")
+    }
+}

--- a/Sources/KituraNIO/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNIO/FastCGI/FastCGIServerRequest.swift
@@ -1,0 +1,133 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+import LoggerAPI
+
+/// The FastCGIServerRequest class implements the `ServerRequest` protocol
+/// for incoming HTTP requests that come in over a FastCGI connection.
+public class FastCGIServerRequest : ServerRequest {
+
+    /// The IP address of the client
+    public private(set) var remoteAddress: String = ""
+
+    /// Major version of HTTP of the request
+    public private(set) var httpVersionMajor: UInt16? = 0
+
+    /// Minor version of HTTP of the request
+    public private(set) var httpVersionMinor: UInt16? = 9
+
+    /// The set of HTTP headers received with the incoming request
+    public var headers = HeadersContainer()
+
+    /// The set of non-HTTP headers received with the incoming request
+    public var fastCGIHeaders = HeadersContainer()
+
+    /// The HTTP Method specified in the request
+    public private(set) var method: String = ""
+
+    /// URI Component received from FastCGI
+    private var requestUri : String? = nil
+
+    public private(set) var urlURL = URL(string: "http://not_available/")!
+
+    /// The URL from the request in string form
+    /// This contains just the path and query parameters starting with '/'
+    /// Use 'urlURL' for the full URL
+    @available(*, deprecated, message:
+    "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+    public var urlString : String { return requestUri ?? "" }
+
+    /// The URL from the request in UTF-8 form
+    /// This contains just the path and query parameters starting with '/'
+    /// Use 'urlURL' for the full URL
+    public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
+
+    /// The URL from the request as URLComponents
+    /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
+    @available(*, deprecated, message:
+    "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
+    public lazy var urlComponents: URLComponents = { [unowned self] () in
+        return URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        }()
+
+    /// Chunk of body read in by the http_parser, filled by callbacks to onBody
+    private var bodyChunk = BufferList()
+
+    /// State of incoming message handling
+    private var status = Status.initial
+
+    /// The request ID established by the FastCGI client.
+    public private(set) var requestId : UInt16 = 0
+
+    /// An array of request ID's that are not our primary one.
+    /// When the main request is done, the FastCGIServer can reject the
+    /// extra requests as being unusable.
+    public private(set) var extraRequestIds : [UInt16] = []
+
+    /// Some defaults
+    private static let defaultMethod : String = "GET"
+
+    /// List of status states
+    private enum Status {
+        case initial
+        case requestStarted
+        case headersComplete
+        case requestComplete
+    }
+
+    /// HTTP parser error types
+    public enum FastCGIParserErrorType {
+        case success
+        case protocolError
+        case invalidType
+        case clientDisconnect
+        case unsupportedRole
+        case internalError
+    }
+    
+    public init () {
+    }
+
+    /// Read data from the body of the request
+    ///
+    /// - Parameter data: A Data struct to hold the data read in.
+    ///
+    /// - Throws: Socket.error if an error occurred while reading from the socket.
+    /// - Returns: The number of bytes read.
+    public func read(into data: inout Data) throws -> Int {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Read all of the data in the body of the request
+    ///
+    /// - Parameter data: A Data struct to hold the data read in.
+    ///
+    /// - Throws: Socket.error if an error occurred while reading from the socket.
+    /// - Returns: The number of bytes read.
+    public func readAllData(into data: inout Data) throws -> Int {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Read a string from the body of the request.
+    ///
+    /// - Throws: Socket.error if an error occurred while reading from the socket.
+    /// - Returns: An Optional string.
+    public func readString() throws -> String? {
+        fatalError("FastCGI not implemented yet.")
+    }
+}

--- a/Sources/KituraNIO/FastCGI/FastCGIServerResponse.swift
+++ b/Sources/KituraNIO/FastCGI/FastCGIServerResponse.swift
@@ -1,0 +1,124 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+// TBD: Bound should be of type Int i.e. Bound == Int. Currently this syntax is unavailable, expected to be shipped with Swift 3.1.
+// https://forums.developer.apple.com/thread/6627
+#if !swift(>=4)
+    typealias BinaryInteger = IntegerArithmetic
+#endif
+
+extension Range where Bound: BinaryInteger {
+    func iterate(by delta: Bound, action: (Range<Bound>) throws -> ()) throws {
+
+        var base = self.lowerBound
+
+        while (base < self.upperBound) {
+            let subRange = (base ..< (base + delta)).clamped(to: self)
+            try action(subRange)
+
+            base += delta
+        }
+    }
+}
+
+/// The FastCGIServerRequest class implements the `ServerResponse` protocol
+/// for incoming HTTP requests that come in over a FastCGI connection.
+public class FastCGIServerResponse : ServerResponse {
+
+    /// Size of buffers (64 * 1024 is the max size for a FastCGI outbound record)
+    /// Which also gives a bit more internal buffer room.
+    private static let bufferSize = 64 * 1024
+
+    /// Buffer for HTTP response line, headers, and short bodies
+    private var buffer = Data(capacity: FastCGIServerResponse.bufferSize)
+
+    /// Whether or not the HTTP response line and headers have been flushed.
+    private var startFlushed = false
+
+    /// The headers to send back as part of the HTTP response.
+    public var headers = HeadersContainer()
+
+    /// Status code
+    private var status = HTTPStatusCode.OK.rawValue
+
+    /// Corresponding server request
+    private weak var serverRequest : FastCGIServerRequest?
+
+    /// The status code to send in the HTTP response.
+    public var statusCode: HTTPStatusCode? {
+        get {
+            return HTTPStatusCode(rawValue: status)
+        }
+        set (newValue) {
+            if let newValue = newValue, !startFlushed {
+                status = newValue.rawValue
+            }
+        }
+    }
+
+    /// Add a string to the body of the HTTP response and complete sending the HTTP response
+    ///
+    /// - Parameter text: The String to add to the body of the HTTP response.
+    ///
+    /// - Throws: Socket.error if an error occurred while writing to the socket
+    public func end(text: String) throws {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Add a string to the body of the HTTP response.
+    ///
+    /// - Parameter string: The String data to be added.
+    ///
+    /// - Throws: Socket.error if an error occurred while writing to the socket
+    public func write(from string: String) throws {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Add bytes to the body of the HTTP response.
+    ///
+    /// - Parameter data: The Data struct that contains the bytes to be added.
+    ///
+    /// - Throws: Socket.error if an error occurred while writing to the socket
+    public func write(from data: Data) throws {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Complete sending the HTTP response
+    ///
+    /// - Throws: Socket.error if an error occurred while writing to a socket
+    public func end() throws {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// External message write for multiplex rejection
+    ///
+    /// - Parameter requestId: The id of the request to reject.
+    public func rejectMultiplexConnecton(requestId: UInt16) throws {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// External message write for role rejection
+    public func rejectUnsupportedRole() throws {
+        fatalError("FastCGI not implemented yet.")
+    }
+
+    /// Reset the request for reuse in Keep alive
+    public func reset() {
+        /*****  TBD *******/
+    }
+}


### PR DESCRIPTION
This code is copied from https://github.com/IBM-Swift/Kitura-net/tree/master/Sources/KituraNet/FastCGI

The stubs need to be replaced by proper SwiftNIO based implementations.