### PR TITLE
Fix SSL test failures on Darwin

### DIFF
--- a/Sources/KituraNIO/HTTP/SSLConfiguration.swift
+++ b/Sources/KituraNIO/HTTP/SSLConfiguration.swift
@@ -34,16 +34,12 @@ internal class SSLConfiguration {
 
     /// Convert SSLService.Configuration to NIOOpenSSL.TLSConfiguration
     func tlsServerConfig() -> TLSConfiguration? {
-        #if os(Linux)
             // TODO: Consider other configuration options
+            // TODO: Add support for PKCS#12-formatted certificates
             if let certificateFilePath = certificateFilePath, let keyFilePath = keyFilePath {
                 return TLSConfiguration.forServer(certificateChain: [.file(certificateFilePath)], privateKey: .file(keyFilePath))
             } else {
                 return nil
             }
-        #else
-            // TODO: Add support for other platforms
-            fatalError("Not supported")
-        #endif
     }
 }

--- a/Tests/KituraNIOTests/KituraNIOTest.swift
+++ b/Tests/KituraNIOTests/KituraNIOTest.swift
@@ -38,16 +38,14 @@ class KituraNetTest: XCTestCase {
     static let sslConfig: SSLService.Configuration = {
         let sslConfigDir = URL(fileURLWithPath: #file).appendingPathComponent("../SSLConfig")
 
-        #if os(Linux)
             let certificatePath = sslConfigDir.appendingPathComponent("certificate.pem").standardized.path
             let keyPath = sslConfigDir.appendingPathComponent("key.pem").standardized.path
             return SSLService.Configuration(withCACertificateDirectory: nil, usingCertificateFile: certificatePath,
                                             withKeyFile: keyPath, usingSelfSignedCerts: true, cipherSuite: nil)
-        #else
-            let chainFilePath = sslConfigDir.appendingPathComponent("certificateChain.pfx").standardized.path
-            return SSLService.Configuration(withChainFilePath: chainFilePath, withPassword: "kitura",
-                                            usingSelfSignedCerts: true, cipherSuite: nil)
-        #endif
+
+            /// TODO: We will need to reenable this. `swift nio-ssl` doesn't support PKCS#12-formatted certificates
+            // let chainFilePath = sslConfigDir.appendingPathComponent("certificateChain.pfx").standardized.path
+            // return SSLService.Configuration(withChainFilePath: chainFilePath, withPassword: "kitura", usingSelfSignedCerts: true, cipherSuite: nil)
     }()
     
     static let clientSSLConfig = SSLService.Configuration(withCipherSuite: nil, clientAllowsSelfSignedCertificates: true)


### PR DESCRIPTION
`swift nio-ssl` doesn't add support for PKCS#12-formatted certificates. Hence we test only with PEM formatted certificates.