### PR TITLE
Fix a warning in LinuxTest.main

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -25,7 +25,7 @@ extension MutableCollection {
 
         srand(UInt32(time(nil)))
         for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
-            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
+            let d: Int = numericCast(random() % numericCast(unshuffledCount))
             guard d != 0 else { continue }
             let i = index(firstUnshuffled, offsetBy: d)
             swapAt(firstUnshuffled, i)


### PR DESCRIPTION
```
 warning: 'IndexDistance' is deprecated: all index distances are now of type Int
            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
```