### PR TITLE
Fix a perf regression caused by PR #33

### DIFF
--- a/Sources/KituraNIO/ClientResponse.swift
+++ b/Sources/KituraNIO/ClientResponse.swift
@@ -49,7 +49,7 @@ public class ClientResponse {
         }
 
         set {
-           _headers = newValue.httpHeaders
+           _headers = newValue.httpHeaders()
         }
     }
     /// The HTTP Status code, as an Int, sent in the response by the remote server.

--- a/Sources/KituraNIO/HTTP/HeadersContainer.swift
+++ b/Sources/KituraNIO/HTTP/HeadersContainer.swift
@@ -26,9 +26,6 @@ public class HeadersContainer {
     /// The header storage
     internal var headers: [String: (key: String, value: [String])] = [:]
     
-    /// Will be used only by ServerResponse
-    internal var httpHeaders = HTTPHeaders()
-
     /// Create an instance of `HeadersContainer`
     public init() {}
 
@@ -46,11 +43,9 @@ public class HeadersContainer {
         set(newValue) {
             if let newValue = newValue {
                 set(key, value: newValue)
-                httpHeaders.replaceOrAdd(name: key, values: newValue)
             }
             else {
                 remove(key)
-                httpHeaders.remove(name: key)
             }
         }
     }
@@ -72,7 +67,6 @@ public class HeadersContainer {
             } else {
                 set(key, lowerCaseKey: lowerCaseKey, value: value)
             }
-            httpHeaders.add(name: key, values: value)
             
         case "content-type", "content-length", "user-agent", "referer", "host",
              "authorization", "proxy-authorization", "if-modified-since",
@@ -87,12 +81,10 @@ public class HeadersContainer {
         default:
             guard let oldValue = entry?.value.first else {
                 set(key, lowerCaseKey: lowerCaseKey, value: value)
-                httpHeaders.add(name: key, values: value)
                 return
             }
             let newValue = oldValue + ", " + value.joined(separator: ", ")
             headers[lowerCaseKey]?.value[0] = newValue
-            httpHeaders.replaceOrAdd(name: key, value: newValue)
         }
     }
 
@@ -111,7 +103,6 @@ public class HeadersContainer {
     /// Remove all of the headers
     public func removeAll() {
         headers.removeAll(keepingCapacity: true)
-        httpHeaders = HTTPHeaders()
     }
     
     private func set(_ key: String, value: [String]) {
@@ -182,6 +173,16 @@ extension HeadersContainer {
             headerContainer.append(header.name, value: header.value)
         }
         return headerContainer
+    }
+
+    func httpHeaders() -> HTTPHeaders {
+        var httpHeaders = HTTPHeaders()
+        for (_, keyValues) in headers {
+            for value in keyValues.1 {
+                httpHeaders.add(name: keyValues.0, value: value)
+            }
+        }
+        return httpHeaders
     }
 }
 

--- a/Tests/KituraNIOTests/HTTPResponseTests.swift
+++ b/Tests/KituraNIOTests/HTTPResponseTests.swift
@@ -62,23 +62,23 @@ class HTTPResponseTests: KituraNetTest {
     func testHeadersContainerHTTPHeaders() {
         let headers = HeadersContainer()
         headers["Content-Type"] = ["image/png, text/plain"]
-        XCTAssertEqual(headers.httpHeaders["Content-Type"], headers["Content-Type"])
+        XCTAssertEqual(headers.httpHeaders()["Content-Type"], headers["Content-Type"]!)
         headers["Content-Type"] = ["text/html"]
-        XCTAssertEqual(headers.httpHeaders["Content-Type"], headers["Content-Type"])
+        XCTAssertEqual(headers.httpHeaders()["Content-Type"], headers["Content-Type"]!)
         headers["Content-Type"] = nil
-        XCTAssertFalse(headers.httpHeaders.contains(name: "Content-Type"))
+        XCTAssertFalse(headers.httpHeaders().contains(name: "Content-Type"))
         headers["Set-Cookie"] = ["ID=123BAS; Path=/; Secure; HttpOnly"]
         headers.append("Set-Cookie", value: ["ID=KI9H12; Path=/; Secure; HttpOnly"])
-        XCTAssertEqual(headers["Set-Cookie"], headers.httpHeaders["Set-Cookie"])
+        XCTAssertEqual(headers["Set-Cookie"]!, headers.httpHeaders()["Set-Cookie"])
         headers["Content-Type"] = ["text/html"]
         headers.append("Content-Type", value: "text/json")
-        XCTAssertEqual(headers.httpHeaders["Content-Type"], headers["Content-Type"])
+        XCTAssertEqual(headers.httpHeaders()["Content-Type"], headers["Content-Type"]!)
         headers["foo"] = ["bar0"]
         headers.append("foo", value: "bar1")
-        XCTAssertEqual(headers.httpHeaders["foo"], headers["foo"])
+        XCTAssertEqual(headers.httpHeaders()["foo"], headers["foo"]!)
         headers.append("foo", value: ["bar2", "bar3"])
-        XCTAssertEqual(headers.httpHeaders["foo"], headers["foo"])
+        XCTAssertEqual(headers.httpHeaders()["foo"], headers["foo"]!)
         headers.removeAll()
-        XCTAssertFalse(headers.httpHeaders.contains(name: "foo"))
+        XCTAssertFalse(headers.httpHeaders().contains(name: "foo"))
     }
 }


### PR DESCRIPTION
Apologies, though the HTTPHeaders -> HeadersContainer conversion was lazy, the vice versa wasn't. It led to a perf regression with a small number of headers (which is a more common case than a large number of headers).