### PR TITLE
Remove redundant HTTP headers

### DIFF
--- a/Sources/KituraNIO/HTTP/HTTPServer.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServer.swift
@@ -107,8 +107,6 @@ public class HTTPServer : Server {
         if let webSocketHandlerFactory = ConnectionUpgrader.getProtocolHandlerFactory(for: "websocket") {
             let upgrader = WebSocketUpgrader(shouldUpgrade: { (head: HTTPRequestHead) in
                 var headers = HTTPHeaders()
-                headers.add(name: "Connection", value: "upgrade")
-                headers.add(name: "upgrade", value: "websocket")
                 ///TODO: Handle multiple protocols
                 if let wsProtocol = head.headers["Sec-WebSocket-Protocol"].first {
                     headers.add(name: "Sec-WebSocket-Protocol", value: wsProtocol)

--- a/Sources/KituraNIO/HTTP/SSLConfiguration.swift
+++ b/Sources/KituraNIO/HTTP/SSLConfiguration.swift
@@ -17,7 +17,7 @@
 import NIOOpenSSL
 import SSLService
 
-/// A helper class to bridge betweem SSLService.Configuration (used by Kitura) and TLSConfiguration requred by NIOOpenSSL
+/// A helper class to bridge betweem SSLService.Configuration (used by Kitura) and TLSConfiguration required by NIOOpenSSL
 internal class SSLConfiguration {
    
     private var certificateFilePath: String? = nil


### PR DESCRIPTION
`Connection` and `Upgrade` headers are handled and added by swift-nio. Hence we can remove this.