### PR TITLE
setting authorization header if username and password are not nil

### DIFF
--- a/Sources/KituraNIO/ClientRequest.swift
+++ b/Sources/KituraNIO/ClientRequest.swift
@@ -365,6 +365,10 @@ public class ClientRequest {
             self.headers["Connection"] = "close"
         }
 
+        if let username = self.userName, let password = self.password {
+            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
+        }
+
         if self.port == nil {
             self.port = enableSSLVerification ? 443 : 80
         }
@@ -415,6 +419,14 @@ public class ClientRequest {
                     channel.pipeline.add(handler: HTTPClientHandler(request: self))
                 }
             }
+    }
+
+    private func createHTTPBasicAuthHeader(username: String, password: String) -> String? {
+        let authHeader = "\(username):\(password)"
+        guard let data = authHeader.data(using: String.Encoding.utf8) else {
+            return nil
+        }
+        return "Basic \(data.base64EncodedString)"
     }
 }
 


### PR DESCRIPTION
Problem: Authorization headers are not getting set by Kitura-NIO to the request header even if username and password  fields are set by the client.

Authorization header needs to be set based on the auth-scheme  preferred by the user.If username and password are set, treat it as basic authentication scheme and set the authorization header accordingly. 