### PR TITLE
Avoid a compilation failure in Xcode

### DIFF
--- a/Sources/KituraNIO/HTTP/HTTPServer.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServer.swift
@@ -85,7 +85,7 @@ public class HTTPServer : Server {
     private var tlsConfig: TLSConfiguration?
 
     /// The SSLContext built using the TLSConfiguration
-    private var sslContext: SSLContext?
+    private var sslContext: NIOOpenSSL.SSLContext?
 
 
     /// Listens for connections on a socket


### PR DESCRIPTION
This happens only in Xcode 10 beta and only with the changes of #43 
<img width="981" alt="screen shot 2018-07-04 at 2 47 58 pm" src="https://user-images.githubusercontent.com/4761859/42268497-4c5035ee-7f99-11e8-8b90-5c38810b8197.png">
