### PR TITLE
bind to the unspecified IPv4 address by default

### DIFF
--- a/Sources/KituraNIO/HTTP/HTTPServer.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServer.swift
@@ -143,7 +143,7 @@ public class HTTPServer : Server {
             .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
 
         do {
-            serverChannel = try bootstrap.bind(host: "::", port: port).wait()
+            serverChannel = try bootstrap.bind(host: "0.0.0.0", port: port).wait()
             self.port = serverChannel?.localAddress?.port.map { Int($0) }
             self.state = .started
             self.lifecycleListener.performStartCallbacks()


### PR DESCRIPTION
`::` won't bind on systems where IPv6 is disabled