### PR TITLE
Increase the WebSocket frame size

### DIFF
--- a/Sources/KituraNIO/HTTP/HTTPServer.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServer.swift
@@ -101,7 +101,8 @@ public class HTTPServer : Server {
         var channelHandlerCtx: ChannelHandlerContext?
         var upgraders: [HTTPProtocolUpgrader] = []
         if let webSocketHandlerFactory = ConnectionUpgrader.getProtocolHandlerFactory(for: "websocket") {
-            let upgrader = WebSocketUpgrader(shouldUpgrade: { (head: HTTPRequestHead) in
+            ///TODO: Should `maxFrameSize` be configurable?
+            let upgrader = WebSocketUpgrader(maxFrameSize: 1 << 16, shouldUpgrade: { (head: HTTPRequestHead) in
                 var headers = HTTPHeaders()
                 ///TODO: Handle multiple protocols
                 if let wsProtocol = head.headers["Sec-WebSocket-Protocol"].first {


### PR DESCRIPTION
Websocket upgrade fails for a larger payload above 16,384 bytes. This is because the default frame size for the websocket decoder  to tolerate is only 2^14 (16,384) bytes. Hence we can increase the frame size for the decoder to tolerate upto 2^16 ie. 65,536 bytes.
