### PR TITLE
Increase WebSocket frame size 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", .branch("master")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.1"),
         .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),

--- a/Sources/KituraNIO/HTTP/HTTPServer.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServer.swift
@@ -102,7 +102,7 @@ public class HTTPServer : Server {
         var upgraders: [HTTPProtocolUpgrader] = []
         if let webSocketHandlerFactory = ConnectionUpgrader.getProtocolHandlerFactory(for: "websocket") {
             ///TODO: Should `maxFrameSize` be configurable?
-            let upgrader = WebSocketUpgrader(maxFrameSize: 1 << 16, shouldUpgrade: { (head: HTTPRequestHead) in
+            let upgrader = WebSocketUpgrader(maxFrameSize: 1 << 24, shouldUpgrade: { (head: HTTPRequestHead) in
                 var headers = HTTPHeaders()
                 ///TODO: Handle multiple protocols
                 if let wsProtocol = head.headers["Sec-WebSocket-Protocol"].first {


### PR DESCRIPTION
**Note:** WebSocket frame size is increased to 2^24 (1M) bytes to support Autobahn testing