### PR TITLE
Import Dispatch in ClientRequest

### DIFF
--- a/Sources/KituraNIO/ClientRequest.swift
+++ b/Sources/KituraNIO/ClientRequest.swift
@@ -19,6 +19,7 @@ import NIOHTTP1
 import Foundation
 import NIOOpenSSL
 import LoggerAPI
+import Dispatch
 
 /// This class provides a set of low level APIs for issuing HTTP requests to another server.
 public class ClientRequest {


### PR DESCRIPTION
swift-4.0.3 requires `import Dispatch` for travis builds