### PR TITLE
Check if the URI is valid before upgrading

### DIFF
--- a/Sources/KituraNIO/ConnectionUpgrader.swift
+++ b/Sources/KituraNIO/ConnectionUpgrader.swift
@@ -42,7 +42,12 @@ public struct ConnectionUpgrader {
 }
 
 public protocol ProtocolHandlerFactory {
+    //Name of the protocol
     var name: String { get }
 
+    //Supplies an NIO channel handler for the protocol. Every upgrade will return a single handler.
     func handler(for request: ServerRequest) -> ChannelHandler
+
+    //Checks if a service is available/registered at the given URI
+    func isServiceRegistered(at path: String) -> Bool
 }

--- a/Sources/KituraNIO/HTTP/HTTPServer.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServer.swift
@@ -103,13 +103,15 @@ public class HTTPServer : Server {
         if let webSocketHandlerFactory = ConnectionUpgrader.getProtocolHandlerFactory(for: "websocket") {
             ///TODO: Should `maxFrameSize` be configurable?
             let upgrader = WebSocketUpgrader(maxFrameSize: 1 << 24, automaticErrorHandling: false, shouldUpgrade: { (head: HTTPRequestHead) in
+                guard webSocketHandlerFactory.isServiceRegistered(at: head.uri) else { return nil }
                 var headers = HTTPHeaders()
-                ///TODO: Handle multiple protocols
                 if let wsProtocol = head.headers["Sec-WebSocket-Protocol"].first {
                     headers.add(name: "Sec-WebSocket-Protocol", value: wsProtocol)
                 }
+                if let key =  head.headers["Sec-WebSocket-Key"].first {
+                    headers.add(name: "Sec-WebSocket-Key", value: key)
+                }
                 return headers
-
                 }, upgradePipelineHandler: { (channel: Channel, request: HTTPRequestHead) in
                     guard let ctx = channelHandlerCtx else { fatalError("Cannot create ServerRequest") }
                     ///TODO: Handle secure upgrade request ("wss://")


### PR DESCRIPTION
For an upgrade to a protocol like WebSocket, we must be able to check if the requested URI has a service registered. If not, `shouldUpgrade` must flag that error by returning nil. This will cause the NIOWebSocket upgrader to throw `unsupportedWebSocketTarget` error which must be again handled by the `errorCaught` callback of the `HTTPHandler`. 

Note that we are handling this error within the HTTP server. We don't upgrade if this error is thrown. 