### PR TITLE
Fix a build failure caused by GitHub's inability to flag a merge conflict

### DIFF
--- a/Sources/KituraNIO/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNIO/HTTP/HTTPServerResponse.swift
@@ -160,15 +160,15 @@ public class HTTPServerResponse: ServerResponse {
             fatalError("No channel handler context available.")
         }
         if ctx.eventLoop.inEventLoop {
-            try end0(with: errorCode, ctx: ctx)
+            try end0(with: errorCode, ctx: ctx, withBody: withBody)
         } else {
             ctx.eventLoop.execute {
-                try! self.end0(with: errorCode, ctx: ctx)
+                try! self.end0(with: errorCode, ctx: ctx, withBody: withBody)
             }
         }
     }
 
-    func end0(with errorCode: HTTPStatusCode, ctx: ChannelHandlerContext) throws {
+    private func end0(with errorCode: HTTPStatusCode, ctx: ChannelHandlerContext, withBody: Bool = false) throws {
         guard let handler = self.handler else {
             fatalError("No HTTP handler available")
         }
@@ -187,7 +187,7 @@ public class HTTPServerResponse: ServerResponse {
         handler.updateKeepAliveState()
 
         if let request = handler.serverRequest {
-                Monitor.delegate?.finished(request: request, response: self)
+            Monitor.delegate?.finished(request: request, response: self)
         }
     }
 


### PR DESCRIPTION
#64 was merged before #65 and GitHub should've ideally flagged a merge conflict on the latter, and sought manual resolution. It didn't, and this broke the master. Fixing it up now.