### PR TITLE
 Retain the latest WebSocket URI for building error messages

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPHandler.swift
@@ -107,7 +107,7 @@ public class HTTPHandler: ChannelInboundHandler {
         case KituraWebSocketUpgradeError.invalidVersionHeader(_):
             message = "Only WebSocket protocol version 13 is supported"
         case NIOWebSocketUpgradeError.unsupportedWebSocketTarget:
-            let target = String(data: serverRequest.url , encoding: String.Encoding.utf8) ?? "/<unknown>"
+            let target = server.latestWebSocketURI ?? "/<unknown>"
             message = "No service has been registered for the path \(target)"
         default:
             if error is HTTPParserError {

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -104,7 +104,7 @@ public class HTTPServer : Server {
         var upgraders: [HTTPProtocolUpgrader] = []
         if let webSocketHandlerFactory = ConnectionUpgrader.getProtocolHandlerFactory(for: "websocket") {
             ///TODO: Should `maxFrameSize` be configurable?
-            let upgrader = WebSocketUpgrader(maxFrameSize: 1 << 24, automaticErrorHandling: false, shouldUpgrade: { (head: HTTPRequestHead) in
+            let upgrader = KituraWebSocketUpgrader(maxFrameSize: 1 << 24, automaticErrorHandling: false, shouldUpgrade: { (head: HTTPRequestHead) in
                 self.latestWebSocketURI = head.uri
                 guard webSocketHandlerFactory.isServiceRegistered(at: head.uri) else { return nil }
                 var headers = HTTPHeaders()

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -87,6 +87,8 @@ public class HTTPServer : Server {
     /// The SSLContext built using the TLSConfiguration
     private var sslContext: NIOOpenSSL.SSLContext?
 
+    /// URI for which the latest WebSocket upgrade was requested by a client
+    var latestWebSocketURI: String?
 
     /// Listens for connections on a socket
     ///
@@ -103,6 +105,7 @@ public class HTTPServer : Server {
         if let webSocketHandlerFactory = ConnectionUpgrader.getProtocolHandlerFactory(for: "websocket") {
             ///TODO: Should `maxFrameSize` be configurable?
             let upgrader = WebSocketUpgrader(maxFrameSize: 1 << 24, automaticErrorHandling: false, shouldUpgrade: { (head: HTTPRequestHead) in
+                self.latestWebSocketURI = head.uri
                 guard webSocketHandlerFactory.isServiceRegistered(at: head.uri) else { return nil }
                 var headers = HTTPHeaders()
                 if let wsProtocol = head.headers["Sec-WebSocket-Protocol"].first {


### PR DESCRIPTION
In the case of a requested WebSocket service not being registered, the WebSocket server is expected to return an error message like: `No service has been registered for the path /testing123`. To access the URI in the `errorCaught` callback, we need to store it in the server instance. That seems like the only way out.