### PR TITLE
Shut down the eventloop gracefully in ClientRequest

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -380,6 +380,14 @@ public class ClientRequest {
             self.port = isHTTPS ? 443 : 80
         }
 
+        defer {
+            do {
+                try group.syncShutdownGracefully()
+            } catch {
+                Log.error("ClientRequest failed to shut down the EventLoopGroup for the requested URL: \(url)")
+            }
+        }
+
         do {
             channel = try bootstrap.connect(host: hostName, port: Int(self.port ?? 80)).wait()
         } catch let error {


### PR DESCRIPTION
ClientRequest leaks threads because we don't shutdown the MultiThreadedEventLoop group associated with it. This PR resolves the leak by shutting down every `MultiThreadedEventLoopGroup` that were created in the application using `syncShutdownGracefully()`
