### PR TITLE
Install pkg-config on Ubuntu 16.04 docker

### DIFF
--- a/.swift-test-linux
+++ b/.swift-test-linux
@@ -1,1 +1,0 @@
-swift test -Xlinker -lz

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,8 @@ set -o verbose
 
 if [ -n "${DOCKER_IMAGE}" ]; then
     docker pull ${DOCKER_IMAGE}
-    docker run --privileged --env SWIFT_SNAPSHOT -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
+    docker run --privileged --env SWIFT_SNAPSHOT -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config && cd $TRAVIS_BUILD_DIR && ./build.sh"
 else
-    sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
     git clone https://github.com/IBM-Swift/Package-Builder.git
     ./Package-Builder/build-package.sh -projectDir $(pwd)
 fi


### PR DESCRIPTION
`pkg-config` is not installed on Ubuntu 16.04 docker. And hence we get linker error in libz. Installing `pkg-config` resolves the issue. 




