### PR TITLE
Run the Kitura router on a DispatchQueue instead of an ELT

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -138,7 +138,7 @@ public class HTTPServer : Server {
                     _ = channel.pipeline.remove(handler: httpHandler)
                 })
                 return channel.pipeline.add(handler: IdleStateHandler(allTimeout: TimeAmount.seconds(Int(HTTPHandler.keepAliveTimeout)))).then {
-                    return channel.pipeline.configureHTTPServerPipeline(withServerUpgrade: config).then { () -> EventLoopFuture<Void> in
+                    return channel.pipeline.configureHTTPServerPipeline(withServerUpgrade: config, withErrorHandling: true).then { () -> EventLoopFuture<Void> in
                         if let sslContext = self.sslContext {
                             _ = channel.pipeline.add(handler: try! OpenSSLServerHandler(context: sslContext), first: true)
                         }
@@ -275,7 +275,7 @@ public class HTTPServer : Server {
     }
 }
 
-private class HTTPDummyServerDelegate: ServerDelegate {
+class HTTPDummyServerDelegate: ServerDelegate {
     /// Handle new incoming requests to the server
     ///
     /// - Parameter request: The ServerRequest class instance for working with this request.

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -167,7 +167,7 @@ class RegressionTests: KituraNetTest {
     /// This is to verify the fix introduced in Kitura-net PR #229, where a malformed
     /// request sent during a Keep-Alive session could cause the server to crash.
     func testBadRequestFollowingGoodRequest() {
-       do {
+        do {
             let server: HTTPServer = try startServer(nil, port: 0, useSSL: false, allowPortReuse: false)
             defer {
                 server.stop()
@@ -178,15 +178,12 @@ class RegressionTests: KituraNetTest {
                 return
             }
             XCTAssertTrue(serverPort != 0, "Ephemeral server port not set")
-
             var goodClient = GoodClient(with: HTTPClient(with: self.expectation(description: "Bad request error")))
             try! goodClient.makeGoodRequestFollowedByBadRequest(serverPort)
             waitForExpectations(timeout: 10)
-
         } catch {
             XCTFail("Couldn't start server")
         }
-
     }
 
 
@@ -270,10 +267,10 @@ class RegressionTests: KituraNetTest {
             httpHeaders.add(name: "Connection", value: "Keep-Alive")
             _ = channel.write(NIOAny(HTTPClientRequestPart.head(request)))
             _ = channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
+            sleep(1) //workaround for an apparent swift-nio issue
             let request0 = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .GET,  uri: "#/") 
             _ = channel.write(NIOAny(HTTPClientRequestPart.head(request0)))
             _ = channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
-            
         }    
 
     }


### PR DESCRIPTION
Currently, the Kitura router that eventually invokes the endpoint handlers runs on the event loop threads. This is bad design primarily because the handlers may invoke blocking code which will end up blocking the event loop threads, reducing their availability to handle newer HTTP requests.

This pull request proposes moving the Kitura router invocation to a DispatchQueue, effectively freeing up the event loop thread which was scheduled to handle the related HTTP request. We move back to the event loop while writing the response - `HTTPServerResponse.end()`. Error handling (error responses) is done on the event loop. To write responses we use `Channel`s,  instead of `ChannelHandlerContext`s, owing to the thread-safety provided by them.