### PR TITLE
Set SO_REUSEADDR for all socket channels to avoid bind errors

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -130,6 +130,7 @@ public class HTTPServer : Server {
 
         let bootstrap = ServerBootstrap(group: eventLoopGroup)
             .serverChannelOption(ChannelOptions.backlog, value: BacklogOption.OptionType(self.maxPendingConnections))
+            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), value: allowPortReuse ? 1 : 0)
             .childChannelInitializer { channel in
                 let httpHandler = HTTPHandler(for: self)

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -50,7 +50,7 @@ class ClientE2ETests: KituraNetTest {
     let delegate = TestServerDelegate()
 
     func testHeadRequests() {
-        performServerTest(delegate, allowPortReuse: true) { expectation in
+        performServerTest(delegate) { expectation in
             self.performRequest("head", path: "/headtest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -69,7 +69,7 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testKeepAlive() {
-        performServerTest(delegate, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("get", path: "/posttest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .OK was \(String(describing: response?.statusCode))")
                 if let connectionHeader = response?.headers["Connection"] {
@@ -117,7 +117,7 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testPostRequests() {
-        performServerTest(delegate, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("post", path: "/posttest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -164,7 +164,7 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testPutRequests() {
-        performServerTest(delegate, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("put", path: "/puttest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -211,7 +211,7 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testPatchRequests() {
-        performServerTest(delegate, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("patch", path: "/patchtest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -258,7 +258,7 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testErrorRequests() {
-        performServerTest(delegate, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, asyncTasks: { expectation in
             self.performRequest("plover", path: "/xzzy", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "Status code wasn't .badrequest was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
@@ -267,7 +267,7 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testUrlURL() {
-        performServerTest(TestURLDelegate(), allowPortReuse: true) { expectation in
+        performServerTest(TestURLDelegate()) { expectation in
             self.performRequest("post", path: ClientE2ETests.urlPath, callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 expectation.fulfill()

--- a/Tests/KituraNetTests/LargePayloadTests.swift
+++ b/Tests/KituraNetTests/LargePayloadTests.swift
@@ -40,7 +40,7 @@ class LargePayloadTests: KituraNetTest {
     private let delegate = TestServerDelegate()
 
     func testLargePosts() {
-        performServerTest(delegate, useSSL: false, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, useSSL: false, asyncTasks: { expectation in
             let payload = "[" + contentTypesString + "," + contentTypesString + contentTypesString + "," + contentTypesString + "]"
             self.performRequest("post", path: "/largepost", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
@@ -68,7 +68,7 @@ class LargePayloadTests: KituraNetTest {
     }
 
     func testLargeGets() {
-        performServerTest(delegate, useSSL: false, allowPortReuse: true, asyncTasks: { expectation in
+        performServerTest(delegate, useSSL: false, asyncTasks: { expectation in
             // This test is NOT using self.performRequest, in order to test an extra signature of HTTP.request
             let request = HTTP.request("http://localhost:\(self.port)/largepost") {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -45,7 +45,6 @@ class LifecycleListenerTests: KituraNetTest {
         let startExpectation = self.expectation(description: "start")
 
         let server = HTTP.createServer()
-        server.allowPortReuse = true
         server.started {
             started = true
             startExpectation.fulfill()
@@ -123,7 +122,6 @@ class LifecycleListenerTests: KituraNetTest {
         let startExpectation = self.expectation(description: "start")
 
         let server = HTTP.createServer()
-        server.allowPortReuse = true
         server.started {
             startExpectation.fulfill()
         }
@@ -152,7 +150,6 @@ class LifecycleListenerTests: KituraNetTest {
         let failedCallbackExpectation = self.expectation(description: "failedCallback")
         
         let server = HTTP.createServer()
-        server.allowPortReuse = true
         server.failed(callback: { error in
             failedCallbackExpectation.fulfill()
         })

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -46,7 +46,6 @@ class MonitoringTests: KituraNetTest {
 
         let server = HTTP.createServer()
         server.delegate = TestServerDelegate()
-        server.allowPortReuse = true
         if KituraNetTest.useSSLDefault {
             server.sslConfig = KituraNetTest.sslConfig
         }

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -45,7 +45,6 @@ class PipeliningTests : KituraNetTest {
     func testPipelining() {
         let server = HTTPServer()
         server.delegate = Delegate()
-        server.allowPortReuse = true
         try! server.listen(on: 0)
         let expectation = self.expectation(description: "test pipelining")
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -74,7 +73,6 @@ class PipeliningTests : KituraNetTest {
     func testPipeliningSpanningPackets() {
         let server = HTTPServer()
         server.delegate = Delegate()
-        server.allowPortReuse = true
         try! server.listen(on: 0)
         let expectation = self.expectation(description: "test pipelining spanning packets")
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -56,7 +56,7 @@ class RegressionTests: KituraNetTest {
         do {
             let server: HTTPServer
             let serverPort: Int
-            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: true, allowPortReuse: true)
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: true)
             defer {
                 server.stop()
             }
@@ -85,7 +85,7 @@ class RegressionTests: KituraNetTest {
         do {
             let server: HTTPServer
             let serverPort: Int
-            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: false, allowPortReuse: true)
+            (server, serverPort) = try startEphemeralServer(ClientE2ETests.TestServerDelegate(), useSSL: false)
             defer {
                 server.stop()
             }


### PR DESCRIPTION
**Motivation:**
To allow reuse socket address and port.

Previously swift-nio was overriding `ChannelOptions.socket` ie. allowing only one socket option to set. 

Hence as a work-around we were always reusing the port based on the value of `allowPortReuse` 

With this fix https://github.com/apple/swift-nio/pull/597 , swift-nio allows to set two distinct `ChannelOptions.socket` of one type.  

And so we can have both the options `ChannelOptions.socket` set for the server
```
.serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), value: 1)
.serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
```

With this we reuse the port only when necessary.

