### PR TITLE
Remove forced uwrapped optional try(s)

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -440,8 +440,13 @@ public class ClientRequest {
 
     private func initializeClientBootstrapWithSSL(eventLoopGroup: EventLoopGroup) {
         if let sslConfig = self.sslConfig {
-            sslContext = try! SSLContext(configuration: sslConfig)
+            do {
+                sslContext = try SSLContext(configuration: sslConfig)
+            } catch let error {
+                Log.error("Failed to create SSLContext. Error: \(error)")
+            }
         }
+
         bootstrap = ClientBootstrap(group: eventLoopGroup)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .channelInitializer { channel in

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -147,7 +147,11 @@ public class HTTPServer : Server {
         self.port = port
 
         if let tlsConfig = tlsConfig {
-            self.sslContext = try! SSLContext(configuration: tlsConfig)
+            do {
+                self.sslContext = try SSLContext(configuration: tlsConfig)
+            } catch let error {
+                Log.error("Failed to create SSLContext. Error: \(error)")
+            }
         }
 
         var upgraders: [HTTPProtocolUpgrader] = []
@@ -256,14 +260,22 @@ public class HTTPServer : Server {
         return server
     }
     
-    deinit { 
-        try! eventLoopGroup.syncShutdownGracefully()
+    deinit {
+        do {
+            try eventLoopGroup.syncShutdownGracefully()
+        } catch {
+            Log.error("Failed to shutdown eventLoopGroup")
+        }
     }
 
     /// Stop listening for new connections.
     public func stop() {
         guard serverChannel != nil else { return }
-        try! serverChannel.close().wait()
+        do {
+            try serverChannel.close().wait()
+        } catch let error {
+            Log.error("Failed to close the server channel. Error: \(error)")
+        }
         self.state = .stopped
     }
 


### PR DESCRIPTION
The motive is to remove forced unwrapped optional `try` methods and replace with `do-try-catch ` to avoid crash