### PR TITLE
Do not store the HTTPDummyServerDelegate object

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -164,10 +164,6 @@ public class HTTPServer : Server {
             upgraders.append(upgrader)
         }
 
-        if self.delegate == nil {
-            self.delegate = HTTPDummyServerDelegate()
-        }
-
         let bootstrap = ServerBootstrap(group: eventLoopGroup)
             .serverChannelOption(ChannelOptions.backlog, value: BacklogOption.OptionType(self.maxPendingConnections))
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)


### PR DESCRIPTION
Kitura-Net keeps the HTTP server running even if a delegate isn't provided. We use a HTTPDummyServerDelegate for this purpose. Before this code change, we stored the dummy delegate in the delegate property of HTTPServer. This may be confusing to a user who will rightly think that delegate is nil if it isn't explicitly set.