### PR TITLE
Remove installation for libressl from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,5 @@ matrix:
       sudo: true
       env: SWIFT_SNAPSHOT=4.2
 
-before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install libressl ; fi
-
 script:
     - ./build.sh


### PR DESCRIPTION
`swift-nio-ssl` requires installing libressl on OSX. This has been directly added in the Package builder https://github.com/IBM-Swift/Package-Builder/pull/141. Hence we can remove it from Kitura-NIO