### PR TITLE
Use ephemeral ports in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,17 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04
+      env: DOCKER_IMAGE=ubuntu:16.04 DOCKER_PRIVILEGED=true
     - os: linux
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT DOCKER_PRIVILEGED=true
     - os: linux
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:18.04
+      env: DOCKER_IMAGE=ubuntu:18.04 DOCKER_PRIVILEGED=true
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -258,7 +258,9 @@ class ClientE2ETests: KituraNetTest {
     }
 
     func testUrlURL() {
-        performServerTest(TestURLDelegate()) { expectation in
+        let delegate = TestURLDelegate()
+        performServerTest(delegate) { expectation in
+            delegate.port = self.port
             self.performRequest("post", path: ClientE2ETests.urlPath, callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
@@ -311,12 +313,13 @@ class ClientE2ETests: KituraNetTest {
     }
 
     class TestURLDelegate: ServerDelegate {
+        var port = 0
 
         func handle(request: ServerRequest, response: ServerResponse) {
             XCTAssertEqual(request.httpVersionMajor, 1, "HTTP Major code from KituraNet should be 1, was \(String(describing: request.httpVersionMajor))")
             XCTAssertEqual(request.httpVersionMinor, 1, "HTTP Minor code from KituraNet should be 1, was \(String(describing: request.httpVersionMinor))")
             XCTAssertEqual(request.urlURL.path, urlPath, "Path in request.urlURL wasn't \(urlPath), it was \(request.urlURL.path)")
-            XCTAssertEqual(request.urlURL.port, KituraNetTest.portDefault)
+            XCTAssertEqual(request.urlURL.port, self.port)
             XCTAssertEqual(request.url, urlPath.data(using: .utf8))
             do {
                 response.statusCode = .OK

--- a/Tests/KituraNetTests/KituraNIOTest.swift
+++ b/Tests/KituraNetTests/KituraNIOTest.swift
@@ -28,6 +28,17 @@ struct KituraNetTestError: Swift.Error {
 
 class KituraNetTest: XCTestCase {
 
+    override class func setUp() {
+        func shell(_ args: String...) {
+            let task = Process()
+            task.launchPath = "/usr/bin/env"
+            task.arguments = args
+            task.launch()
+            task.waitUntilExit()
+        }
+        shell("./Tests/KituraNetTests/setup.sh")
+    }
+
     static let useSSLDefault = true
     static let portDefault = 8080
     static let portReuseDefault = false
@@ -92,9 +103,10 @@ class KituraNetTest: XCTestCase {
 
         do {
             self.useSSL = useSSL
+
+            let (server, port) = try startEphemeralServer(delegate, useSSL: useSSL, allowPortReuse: allowPortReuse)
             self.port = port
 
-            let server: HTTPServer = try startServer(delegate, port: port, useSSL: useSSL, allowPortReuse: allowPortReuse)
             defer {
                 server.stop()
             }

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,7 +55,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port)
+            try server.listen(on: 0)
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -127,7 +127,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port)
+            try server.listen(on: 0)
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -52,6 +52,7 @@ class MonitoringTests: KituraNetTest {
 
         server.started {
             DispatchQueue.global().async {
+                self.port = server.port!
                 self.performRequest("get", path: "/plover", callback: { response in
                     XCTAssertNotNil(response, "Received a nil response")
                     XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
@@ -64,8 +65,7 @@ class MonitoringTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: self.port)
-
+            try server.listen(on: 0)
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/setup.sh
+++ b/Tests/KituraNetTests/setup.sh
@@ -1,0 +1,7 @@
+OS=`uname`
+if [ $OS = "Darwin" ]; then
+    sudo sysctl -w net.inet.ip.portrange.first=10000
+    sudo sysctl -w net.inet.ip.portrange.last=20000
+else
+    sudo sysctl -w net.ipv4.ip_local_port_range="10000 20000"
+fi


### PR DESCRIPTION
The tests that create an HTTP server always bind to and listen on port number 8080. Though this is fine when we run the tests sequentially, we run into port collisions when we try to run them in parallel (using `swift test --parallel`). We must ideally be using ephemeral ports to avoid this issue.

The other option is to configure SO_REUSEPORT by default, but with this tests that verify the presence  and absence of SO_REUSEPORT become irrelevant. 

Ephemeral ports may lie in the range starting 16000 and up to 65535. Using the `sysctl` command on Linux and macOS, it is possible to limit them to a given range. In the context of Kitura, limiting them to a range so that the port number can be accommodated in an `UInt16` essential because `ClientRequest.Options.port` is an `UInt16`.