### PR TITLE
Reuse HTTPServerRequest and HTTPServerResponse objects

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -23,9 +23,11 @@ import Foundation
 /// are communicating via the HTTP protocol.
 public class HTTPServerRequest: ServerRequest {
 
+    private var _headersContainer: HeadersContainer
+
     /// Set of HTTP headers of the request.
     public var headers : HeadersContainer {
-        return HeadersContainer.create(from: _headers)
+        return _headersContainer
     }
 
     private var _headers: HTTPHeaders
@@ -128,6 +130,7 @@ public class HTTPServerRequest: ServerRequest {
 
     init(ctx: ChannelHandlerContext, requestHead: HTTPRequestHead, enableSSL: Bool) {
         self._headers = requestHead.headers
+        self._headersContainer = HeadersContainer.create(from: _headers)
         self.method = String(describing: requestHead.method)
         self.httpVersionMajor = requestHead.version.major
         self.httpVersionMinor = requestHead.version.minor

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -35,14 +35,19 @@ public class HTTPServerRequest: ServerRequest {
         return _urlString
     }
 
+    private var _urlData: Data?
+
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     public var url : Data {
-        //The url needs to retain the percent encodings. URL.path doesn't, so we do this.
-        let components = urlURL.absoluteString.components(separatedBy: "/")
-        let path = "/" + components.dropFirst(3).joined(separator: "/")
-        return path.data(using: .utf8) ?? Data()
+        if _urlData == nil {
+            //The url needs to retain the percent encodings. URL.path doesn't, so we do this.
+            let components = urlURL.absoluteString.components(separatedBy: "/")
+            let path = "/" + components.dropFirst(3).joined(separator: "/")
+            _urlData = path.data(using: .utf8) ?? Data()
+        }
+        return _urlData!
     }
 
     @available(*, deprecated, message: "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")


### PR DESCRIPTION
This pull request deals with an optimisation in the context of a special case. It is likely that identical HTTP requests are sent in succession over an HTTP connection. In that case, Kitura-NIO must be able to reuse the request and response abstraction objects (of course, suitably reset).

Reusing HTTPServerRequest objects can make it possible to reuse some of the computed data, by simply caching it, instead of repeating the same computation. See [this commit](https://github.com/IBM-Swift/Kitura-NIO/commit/664709013da1729302ce1787649b05a1202eaf2b) and [this commit](https://github.com/IBM-Swift/Kitura-NIO/commit/147623f19372c579c56c83c5f0566d4fe1937749), for example.

