### PR TITLE
Implement HTTPServerRequest.url in a better way

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -40,9 +40,7 @@ public class HTTPServerRequest: ServerRequest {
     /// Use 'urlURL' for the full URL
     public var url : Data {
         //The url needs to retain the percent encodings. URL.path doesn't, so we do this.
-        let components = urlURL.absoluteString.components(separatedBy: "/")
-        let path = "/" + components.dropFirst(3).joined(separator: "/")
-        return path.data(using: .utf8) ?? Data()
+        return _urlString.data(using: .utf8) ?? Data()
     }
 
     @available(*, deprecated, message: "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")


### PR DESCRIPTION
The url property on HTTPServerRequest.url, which if of type Data, is the Data representation of the URI which includes the path and the query parameters starting with URI. This is available in HTTPRequestHead as a String, which could be simply accessed and converted to Data. This change leads to a performance improvement of ~3%.