### PR TITLE
Do headers translation only once

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -24,11 +24,7 @@ import Foundation
 public class HTTPServerRequest: ServerRequest {
 
     /// Set of HTTP headers of the request.
-    public var headers : HeadersContainer {
-        return HeadersContainer.create(from: _headers)
-    }
-
-    private var _headers: HTTPHeaders
+    public var headers : HeadersContainer
 
     @available(*, deprecated, message: "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var urlString : String {
@@ -60,7 +56,7 @@ public class HTTPServerRequest: ServerRequest {
 
         self.enableSSL ? url.append("https://") : url.append("http://")
 
-        if let hostname = _headers["Host"].first {
+        if let hostname = headers["Host"]?.first {
             url.append(hostname)
             if !hostname.contains(":") {
                 url.append(":")
@@ -122,7 +118,7 @@ public class HTTPServerRequest: ServerRequest {
     }
 
     init(ctx: ChannelHandlerContext, requestHead: HTTPRequestHead, enableSSL: Bool) {
-        self._headers = requestHead.headers
+        self.headers = HeadersContainer.create(from: requestHead.headers)
         self.method = String(describing: requestHead.method)
         self.httpVersionMajor = requestHead.version.major
         self.httpVersionMinor = requestHead.version.minor


### PR DESCRIPTION
Translating HTTPHeaders to HeadersContainer is an inevitable and expensive task. Given that the HTTPHeaders from HTTPRequestHead will not change, the translation could be a one-time thing. Currently, we do the translation everytime the `headers` property is accessed. We could do an eager translation in the initializer or a lazy translation when the property is accessed for the first time. Given that Kitura will most likely access the headers at least once, an eager translation shouldn't be a problem here.