### PR TITLE
Use a switch instead of String(describing:)

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -117,7 +117,7 @@ public class HTTPServerRequest: ServerRequest {
 
     init(ctx: ChannelHandlerContext, requestHead: HTTPRequestHead, enableSSL: Bool) {
         self.headers = HeadersContainer.create(from: requestHead.headers)
-        self.method = String(describing: requestHead.method)
+        self.method = requestHead.method.string()
         self.httpVersionMajor = requestHead.version.major
         self.httpVersionMinor = requestHead.version.minor
         self._urlString = requestHead.uri
@@ -172,5 +172,80 @@ public class HTTPServerRequest: ServerRequest {
             bytesRead += length
         }
         return bytesRead
+    }
+}
+
+extension HTTPMethod {
+    func string() -> String {
+        switch self {
+        case .GET:
+            return "GET"
+        case .PUT:
+            return "PUT"
+        case .ACL:
+            return "ACL"
+        case .HEAD:
+            return "HEAD"
+        case .POST:
+            return "POST"
+        case .COPY:
+            return "COPY"
+        case .LOCK:
+            return "LOCK"
+        case .MOVE:
+            return "MOVE"
+        case .BIND:
+            return "BIND"
+        case .LINK:
+            return "LINK"
+        case .PATCH:
+           return "PATCH"
+        case .TRACE:
+           return "TRACE"
+        case .MKCOL:
+            return "MKCOL"
+        case .MERGE:
+            return "MERGE"
+        case .PURGE:
+            return "PURGE"
+        case .NOTIFY:
+            return "NOTIFY"
+        case .SEARCH:
+            return "SEARCH"
+        case .UNLOCK:
+            return "UNLOCK"
+        case .REBIND:
+            return "REBIND"
+        case .UNBIND:
+            return "UNBIND"
+        case .REPORT:
+            return "REPORT"
+        case .DELETE:
+            return "DELETE"
+        case .UNLINK:
+            return "UNLINK"
+        case .CONNECT:
+            return "CONNECT"
+        case .MSEARCH:
+            return "MSEARCH"
+        case .OPTIONS:
+            return "OPTIONS"
+        case .PROPFIND:
+            return "PROPFIND"
+        case .CHECKOUT:
+            return "CHECKOUT"
+        case .PROPPATCH:
+            return "PROPPATCH"
+        case .SUBSCRIBE:
+            return "SUBSCRIBE"
+        case .MKCALENDAR:
+            return "MKCALENDAR"
+        case .MKACTIVITY:
+            return "MKACTIVITY"
+        case .UNSUBSCRIBE:
+            return "UNSUBSCRIBE"
+        case .RAW(let value):
+            return value
+        }
     }
 }


### PR DESCRIPTION
The NIOHTTP1.HTTPMethod enumeration does not have String as the raw value. We've used `String(describing:)` to get the String representation of an HTTPMethod value. Because this seems to be considerably expensive, compared to a simple switch statement, we could be using the latter instead.