### PR TITLE
Fix: SwiftLint errors and warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,14 +24,14 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "KituraNet",
-            targets: ["KituraNet"]),
+            targets: ["KituraNet"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.1"),
         .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),
+        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -44,6 +44,6 @@ let package = Package(
             dependencies: ["NIO", "NIOFoundationCompat", "NIOHTTP1", "NIOOpenSSL", "SSLService", "LoggerAPI", "NIOWebSocket", "CLinuxHelpers"]),
         .testTarget(
             name: "KituraNetTests",
-            dependencies: ["KituraNet"]),
+            dependencies: ["KituraNet"])
     ]
 )

--- a/Sources/KituraNet/BufferList.swift
+++ b/Sources/KituraNet/BufferList.swift
@@ -79,7 +79,7 @@ public class BufferList {
     ///Fill a `NSMutableData` with data from the buffer.
     public func fill(data: NSMutableData) -> Int {
         let length = byteBuffer.readableBytes
-        let result = byteBuffer.readWithUnsafeReadableBytes() { body in
+        let result = byteBuffer.readWithUnsafeReadableBytes { body in
             data.append(body.baseAddress!, length: length)
             return length
         }

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -157,7 +157,7 @@ public class ClientRequest {
     ///
     /// - Parameter option: an `Options` instance describing the change to be made to the request
     public func set(_ option: Options) {
-        switch(option) {
+        switch option {
         case .schema, .hostname, .port, .path, .username, .password:
             Log.error("Must use ClientRequest.init() to set URL components")
         case .method(let method):
@@ -188,33 +188,33 @@ public class ClientRequest {
         var path = ""
         var port = ""
 
-        for option in options  {
-            switch(option) {
+        for option in options {
+            switch option {
 
-                case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2:
-                    // call set() for Options that do not construct the URL
-                    set(option)
-                case .schema(var schema):
-                    if !schema.contains("://") && !schema.isEmpty {
-                      schema += "://"
-                    }
-                    theSchema = schema
-                case .hostname(let host):
-                    hostName = host
-                    self.hostName = host
-                case .port(let thePort):
-                    port = ":\(thePort)"
-                    self.port = Int(thePort)
-                case .path(var thePath):
-                    if thePath.first != "/" {
-                      thePath = "/" + thePath
-                    }
-                    path = thePath
-                    self.path = path
-                case .username(let userName):
-                    self.userName = userName
-                case .password(let password):
-                    self.password = password
+            case .method, .headers, .maxRedirects, .disableSSLVerification, .useHTTP2:
+                // call set() for Options that do not construct the URL
+                set(option)
+            case .schema(var schema):
+                if !schema.contains("://") && !schema.isEmpty {
+                    schema += "://"
+                }
+                theSchema = schema
+            case .hostname(let host):
+                hostName = host
+                self.hostName = host
+            case .port(let thePort):
+                port = ":\(thePort)"
+                self.port = Int(thePort)
+            case .path(var thePath):
+                if thePath.first != "/" {
+                    thePath = "/" + thePath
+                }
+                path = thePath
+                self.path = path
+            case .username(let userName):
+                self.userName = userName
+            case .password(let password):
+                self.password = password
             }
         }
 
@@ -223,7 +223,7 @@ public class ClientRequest {
         let pwd = self.password ?? ""
         var authenticationClause = ""
         // If either the userName or password are non-empty, add the authenticationClause
-        if (!user.isEmpty || !pwd.isEmpty) {
+        if !user.isEmpty || !pwd.isEmpty {
           authenticationClause = "\(user):\(pwd)@"
         }
 
@@ -392,7 +392,7 @@ public class ClientRequest {
             return
         }
 
-        var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: HTTPMethod.method(from: self.method), uri: path)
+        var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: HTTPMethod.method(from: self.method), uri: path)
         request.headers = HTTPHeaders.from(dictionary: self.headers)
 
         // Make the HTTP request, the response callbacks will be received on the HTTPClientHandler.
@@ -578,7 +578,7 @@ class HTTPClientHandler: ChannelInboundHandler {
          let response = self.unwrapInboundIn(data)
          switch response {
          case .head(let header):
-             clientResponse._headers = header.headers
+             clientResponse.httpHeaders = header.headers
              clientResponse.httpVersionMajor = header.version.major
              clientResponse.httpVersionMinor = header.version.minor
              clientResponse.statusCode = HTTPStatusCode(rawValue: Int(header.status.code))!
@@ -588,7 +588,7 @@ class HTTPClientHandler: ChannelInboundHandler {
              } else {
                  clientResponse.buffer!.byteBuffer.write(buffer: &buffer)
              }
-         case .end(_):
+         case .end:
             // Handle redirection
             if clientResponse.statusCode == .movedTemporarily || clientResponse.statusCode == .movedPermanently {
                 self.clientRequest.redirectCount += 1

--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -37,19 +37,19 @@ public class ClientResponse {
     /// Minor version of HTTP of the response
     public var httpVersionMinor: UInt16?
 
-    internal var _headers: HTTPHeaders?
+    internal var httpHeaders: HTTPHeaders?
 
     /// Set of HTTP headers of the response.
     public var headers: HeadersContainer {
         get {
-            guard let httpHeaders = _headers else {
+            guard let httpHeaders = httpHeaders else {
                 return HeadersContainer()
             }
             return HeadersContainer.create(from: httpHeaders)
         }
 
         set {
-           _headers = newValue.httpHeaders()
+           httpHeaders = newValue.httpHeaders()
         }
     }
     /// The HTTP Status code, as an Int, sent in the response by the remote server.

--- a/Sources/KituraNet/FastCGI/FastCGI.swift
+++ b/Sources/KituraNet/FastCGI/FastCGI.swift
@@ -24,47 +24,47 @@ public class FastCGI {
 
         // general
         //
-        static let FASTCGI_PROTOCOL_VERSION : UInt8 = 1
-        static let FASTCGI_DEFAULT_REQUEST_ID : UInt16 = 0
+        static let FASTCGI_PROTOCOL_VERSION: UInt8 = 1
+        static let FASTCGI_DEFAULT_REQUEST_ID: UInt16 = 0
 
         // FastCGI record types
         //
-        static let FCGI_NO_TYPE : UInt8 = 0
-        static let FCGI_BEGIN_REQUEST : UInt8 = 1
-        static let FCGI_END_REQUEST : UInt8 = 3
-        static let FCGI_PARAMS : UInt8 = 4
-        static let FCGI_STDIN : UInt8 = 5
-        static let FCGI_STDOUT : UInt8 = 6
+        static let FCGI_NO_TYPE: UInt8 = 0
+        static let FCGI_BEGIN_REQUEST: UInt8 = 1
+        static let FCGI_END_REQUEST: UInt8 = 3
+        static let FCGI_PARAMS: UInt8 = 4
+        static let FCGI_STDIN: UInt8 = 5
+        static let FCGI_STDOUT: UInt8 = 6
 
         // sub types
         //
-        static let FCGI_SUBTYPE_NO_TYPE : UInt8 = 99
-        static let FCGI_REQUEST_COMPLETE : UInt8 = 0
-        static let FCGI_CANT_MPX_CONN : UInt8 = 1
-        static let FCGI_UNKNOWN_ROLE : UInt8 = 3
+        static let FCGI_SUBTYPE_NO_TYPE: UInt8 = 99
+        static let FCGI_REQUEST_COMPLETE: UInt8 = 0
+        static let FCGI_CANT_MPX_CONN: UInt8 = 1
+        static let FCGI_UNKNOWN_ROLE: UInt8 = 3
 
         // roles
         //
-        static let FCGI_NO_ROLE : UInt16 = 99
-        static let FCGI_RESPONDER : UInt16 = 1
+        static let FCGI_NO_ROLE: UInt16 = 99
+        static let FCGI_RESPONDER: UInt16 = 1
 
         // flags
         //
-        static let FCGI_KEEP_CONN : UInt8 = 1
+        static let FCGI_KEEP_CONN: UInt8 = 1
 
         // request headers of note
         // we translate these into internal variables
         //
-        static let HEADER_REQUEST_METHOD : String = "REQUEST_METHOD";
-        static let HEADER_REQUEST_SCHEME : String = "REQUEST_SCHEME";
-        static let HEADER_HTTP_HOST : String = "HTTP_HOST";
-        static let HEADER_REQUEST_URI : String = "REQUEST_URI";
+        static let HEADER_REQUEST_METHOD: String = "REQUEST_METHOD";
+        static let HEADER_REQUEST_SCHEME: String = "REQUEST_SCHEME";
+        static let HEADER_HTTP_HOST: String = "HTTP_HOST";
+        static let HEADER_REQUEST_URI: String = "REQUEST_URI";
     }
 
     //
     // Exceptions
     //
-    enum RecordErrors : Swift.Error {
+    enum RecordErrors: Swift.Error {
 
         case invalidType
         case invalidSubType

--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -20,7 +20,7 @@ import LoggerAPI
 
 /// The FastCGIServerRequest class implements the `ServerRequest` protocol
 /// for incoming HTTP requests that come in over a FastCGI connection.
-public class FastCGIServerRequest : ServerRequest {
+public class FastCGIServerRequest: ServerRequest {
 
     /// The IP address of the client
     public private(set) var remoteAddress: String = ""
@@ -41,7 +41,7 @@ public class FastCGIServerRequest : ServerRequest {
     public private(set) var method: String = ""
 
     /// URI Component received from FastCGI
-    private var requestUri : String? = nil
+    private var requestUri: String?
 
     public private(set) var urlURL = URL(string: "http://not_available/")!
 
@@ -50,12 +50,12 @@ public class FastCGIServerRequest : ServerRequest {
     /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
     "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
-    public var urlString : String { return requestUri ?? "" }
+    public var urlString: String { return requestUri ?? "" }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    public var url : Data { return requestUri?.data(using: .utf8) ?? Data() }
+    public var url: Data { return requestUri?.data(using: .utf8) ?? Data() }
 
     /// The URL from the request as URLComponents
     /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
@@ -72,15 +72,15 @@ public class FastCGIServerRequest : ServerRequest {
     private var status = Status.initial
 
     /// The request ID established by the FastCGI client.
-    public private(set) var requestId : UInt16 = 0
+    public private(set) var requestId: UInt16 = 0
 
     /// An array of request ID's that are not our primary one.
     /// When the main request is done, the FastCGIServer can reject the
     /// extra requests as being unusable.
-    public private(set) var extraRequestIds : [UInt16] = []
+    public private(set) var extraRequestIds: [UInt16] = []
 
     /// Some defaults
-    private static let defaultMethod : String = "GET"
+    private static let defaultMethod: String = "GET"
 
     /// List of status states
     private enum Status {

--- a/Sources/KituraNet/FastCGI/FastCGIServerResponse.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerResponse.swift
@@ -23,11 +23,11 @@ import Foundation
 #endif
 
 extension Range where Bound: BinaryInteger {
-    func iterate(by delta: Bound, action: (Range<Bound>) throws -> ()) throws {
+    func iterate(by delta: Bound, action: (Range<Bound>) throws -> Void) throws {
 
         var base = self.lowerBound
 
-        while (base < self.upperBound) {
+        while base < self.upperBound {
             let subRange = (base ..< (base + delta)).clamped(to: self)
             try action(subRange)
 
@@ -38,7 +38,7 @@ extension Range where Bound: BinaryInteger {
 
 /// The FastCGIServerRequest class implements the `ServerResponse` protocol
 /// for incoming HTTP requests that come in over a FastCGI connection.
-public class FastCGIServerResponse : ServerResponse {
+public class FastCGIServerResponse: ServerResponse {
 
     /// Size of buffers (64 * 1024 is the max size for a FastCGI outbound record)
     /// Which also gives a bit more internal buffer room.
@@ -57,7 +57,7 @@ public class FastCGIServerResponse : ServerResponse {
     private var status = HTTPStatusCode.OK.rawValue
 
     /// Corresponding server request
-    private weak var serverRequest : FastCGIServerRequest?
+    private weak var serverRequest: FastCGIServerRequest?
 
     /// The status code to send in the HTTP response.
     public var statusCode: HTTPStatusCode? {

--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -58,7 +58,7 @@ public class HTTP {
         return req
     }
 
-    private static let allowedCharacterSet = NSCharacterSet(charactersIn:"\"#%/<>?@\\^`{|} ").inverted
+    private static let allowedCharacterSet = NSCharacterSet(charactersIn: "\"#%/<>?@\\^`{|} ").inverted
 
     public static func escape(url: String) -> String {
         if let escaped = url.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
@@ -68,7 +68,7 @@ public class HTTP {
     }
 }
 
-// MARK HTTPStatusCode
+// MARK: HTTPStatusCode
 
 /// HTTP status codes and numbers.
 public enum HTTPStatusCode: Int {
@@ -109,12 +109,12 @@ extension HTTPStatusCode {
 
         init(code: Int) {
             switch code {
-                case 100..<200: self = .informational
-                case 200..<300: self = .successful
-                case 300..<400: self = .redirection
-                case 400..<500: self = .clientError
-                case 500..<600: self = .serverError
-                default: self = .invalidStatus
+            case 100..<200: self = .informational
+            case 200..<300: self = .successful
+            case 300..<400: self = .redirection
+            case 400..<500: self = .clientError
+            case 500..<600: self = .serverError
+            default: self = .invalidStatus
             }
         }
     }

--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -62,7 +62,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler {
     public init(for server: HTTPServer) {
         self.server = server
         self.keepAliveState = server.keepAliveState
-        if let _ = server.sslConfig {
+        if server.sslConfig != nil {
             self.enableSSLVerification = true
         }
     }
@@ -92,7 +92,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler {
             } else {
                 serverRequest.buffer!.byteBuffer.write(buffer: &buffer)
             }
-        case .end(_):
+        case .end:
             serverResponse = HTTPServerResponse(channel: ctx.channel, handler: self)
             //Make sure we use the latest delegate registered with the server
             DispatchQueue.global().async {

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -24,7 +24,7 @@ import NIOWebSocket
 import CLinuxHelpers
 
 /// An HTTP server that listens for connections on a socket.
-public class HTTPServer : Server {
+public class HTTPServer: Server {
 
     public typealias ServerType = HTTPServer
 
@@ -341,8 +341,7 @@ class HTTPDummyServerDelegate: ServerDelegate {
             response.headers["Content-Length"] = [String(theBody.utf8.count)]
             try response.write(from: theBody)
             try response.end()
-        }
-        catch {
+        } catch {
             Log.error("Failed to send the response. Error = \(error)")
         }
     }

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -24,29 +24,29 @@ import Foundation
 public class HTTPServerRequest: ServerRequest {
 
     /// Set of HTTP headers of the request.
-    public var headers : HeadersContainer
+    public var headers: HeadersContainer
 
     @available(*, deprecated, message: "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
-    public var urlString : String {
+    public var urlString: String {
         return _urlString
     }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    public var url : Data {
+    public var url: Data {
         //The url needs to retain the percent encodings. URL.path doesn't, so we do this.
         return _urlString.data(using: .utf8) ?? Data()
     }
 
     @available(*, deprecated, message: "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
-    public var urlComponents : URLComponents {
+    public var urlComponents: URLComponents {
         return URLComponents(url: urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
     }
 
     private var _url: URL?
 
-    public var urlURL : URL {
+    public var urlURL: URL {
         if let _url = _url {
             return _url
         }
@@ -98,7 +98,7 @@ public class HTTPServerRequest: ServerRequest {
 
     private var enableSSL: Bool = false
 
-    private var _urlString : String
+    private var _urlString: String
 
     private static func host(socketAddress: SocketAddress?) -> String {
         guard let socketAddress = socketAddress else {
@@ -109,7 +109,7 @@ public class HTTPServerRequest: ServerRequest {
             return addr.host
         case .v6(let addr):
             return addr.host
-        case .unixDomainSocket(_):
+        case .unixDomainSocket:
             return "n/a"
         }
     }

--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -46,7 +46,7 @@ public class HTTPServerResponse: ServerResponse {
     }
 
     /// The HTTP headers to be sent to the client as part of the response.
-    public var headers : HeadersContainer = HeadersContainer()
+    public var headers: HeadersContainer = HeadersContainer()
 
     /// The HTTP version to be sent in the response.
     private var httpVersion: HTTPVersion

--- a/Sources/KituraNet/HTTP/HeadersContainer.swift
+++ b/Sources/KituraNet/HTTP/HeadersContainer.swift
@@ -43,8 +43,7 @@ public class HeadersContainer {
         set(newValue) {
             if let newValue = newValue {
                 set(key, value: newValue)
-            }
-            else {
+            } else {
                 remove(key)
             }
         }
@@ -59,10 +58,10 @@ public class HeadersContainer {
         let lowerCaseKey = key.lowercased()
         let entry = headers[lowerCaseKey]
 
-        switch(lowerCaseKey) {
+        switch lowerCaseKey {
 
         case "set-cookie":
-            if let _ = entry {
+            if entry != nil {
                 headers[lowerCaseKey]?.value += value
             } else {
                 set(key, lowerCaseKey: lowerCaseKey, value: value)
@@ -72,7 +71,7 @@ public class HeadersContainer {
              "authorization", "proxy-authorization", "if-modified-since",
              "if-unmodified-since", "from", "location", "max-forwards",
              "retry-after", "etag", "last-modified", "server", "age", "expires":
-            if let _ = entry {
+            if entry != nil {
                 Log.warning("Duplicate header \(key) discarded")
                 break
             }
@@ -137,10 +136,10 @@ extension HeadersContainer: Collection {
     public typealias Index = DictionaryIndex<String, (key: String, value: [String])>
 
     /// The starting index of the `HeadersContainer` collection
-    public var startIndex:Index { return headers.startIndex }
+    public var startIndex: Index { return headers.startIndex }
 
     /// The ending index of the `HeadersContainer` collection
-    public var endIndex:Index { return headers.endIndex }
+    public var endIndex: Index { return headers.endIndex }
 
     /// Get a (key value) tuple from the `HeadersContainer` collection at the specified position.
     ///
@@ -149,9 +148,7 @@ extension HeadersContainer: Collection {
     ///
     /// - Returns: A (key, value) tuple.
     public subscript(position: Index) -> (key: String, value: [String]) {
-        get {
             return headers[position].value
-        }
     }
 
     /// Get the next Index in the `HeadersContainer` collection after the one specified.
@@ -159,8 +156,8 @@ extension HeadersContainer: Collection {
     /// - Parameter after: The Index whose successor is to be returned.
     ///
     /// - Returns: The Index in the `HeadersContainer` collection after the one specified.
-    public func index(after i: Index) -> Index {
-        return headers.index(after: i)
+    public func index(after index: Index) -> Index {
+        return headers.index(after: index)
     }
 }
 

--- a/Sources/KituraNet/HTTP/KeepAliveState.swift
+++ b/Sources/KituraNet/HTTP/KeepAliveState.swift
@@ -30,7 +30,7 @@ public enum KeepAliveState {
     }
 
     /// Decrements the number of requests remaining
-    mutating func decrement() -> Void {
+    mutating func decrement() {
         switch self {
         case .unlimited: break
         case .limited(let limit):

--- a/Sources/KituraNet/SPIUtils.swift
+++ b/Sources/KituraNet/SPIUtils.swift
@@ -52,23 +52,23 @@ public class SPIUtils {
         let hour = Int(timeStruct.tm_hour)
         let min = Int(timeStruct.tm_min)
         let sec = Int(timeStruct.tm_sec)
-        var s = days[wday]
-        s.reserveCapacity(30)
-        s.append(", ")
-        s.append(twoDigit[mday])
-        s.append(" ")
-        s.append(months[mon])
-        s.append(" ")
-        s.append(twoDigit[year/100])
-        s.append(twoDigit[year%100])
-        s.append(" ")
-        s.append(twoDigit[hour])
-        s.append(":")
-        s.append(twoDigit[min])
-        s.append(":")
-        s.append(twoDigit[sec])
-        s.append(" GMT")
-        return s
+        var time = days[wday]
+        time.reserveCapacity(30)
+        time.append(", ")
+        time.append(twoDigit[mday])
+        time.append(" ")
+        time.append(months[mon])
+        time.append(" ")
+        time.append(twoDigit[year/100])
+        time.append(twoDigit[year%100])
+        time.append(" ")
+        time.append(twoDigit[hour])
+        time.append(":")
+        time.append(twoDigit[min])
+        time.append(":")
+        time.append(twoDigit[sec])
+        time.append(" GMT")
+        return time
 
     }
 

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -22,28 +22,28 @@ import Foundation
 public protocol ServerRequest: class {
 
     /// The set of headers received with the incoming request
-    var headers : HeadersContainer { get }
+    var headers: HeadersContainer { get }
 
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
         "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
-    var urlString : String { get }
+    var urlString: String { get }
 
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    var url : Data { get }
+    var url: Data { get }
 
     /// The URL from the request as URLComponents
     /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
     @available(*, deprecated, message:
         "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
-    var urlComponents : URLComponents { get }
+    var urlComponents: URLComponents { get }
 
     /// The URL from the request
-    var urlURL : URL { get }
+    var urlURL: URL { get }
 
     /// The IP address of the client
     var remoteAddress: String { get }

--- a/Sources/KituraNet/ServerResponse.swift
+++ b/Sources/KituraNet/ServerResponse.swift
@@ -25,7 +25,7 @@ public protocol ServerResponse: class {
     var statusCode: HTTPStatusCode? { get set }
 
     /// The headers to send back as part of the HTTP response.
-    var headers : HeadersContainer { get }
+    var headers: HeadersContainer { get }
 
     /// Add a string to the body of the HTTP response.
     ///

--- a/Sources/KituraNet/URLParser.swift
+++ b/Sources/KituraNet/URLParser.swift
@@ -20,7 +20,7 @@ import Foundation
 ///	**scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]**
 /// We use the URLComponents class from Foundation here.
 
-public class URLParser : CustomStringConvertible {
+public class URLParser: CustomStringConvertible {
 
     /// Schema.
     public var schema: String?
@@ -90,7 +90,7 @@ public class URLParser : CustomStringConvertible {
             self.userinfo = "\(username):\(password)"
         }
         self.port = urlComponents?.port
-        if let queryItems = urlComponents?.queryItems{
+        if let queryItems = urlComponents?.queryItems {
            queryItems.forEach {
                self.queryParameters[$0.name] = $0.value
            }

--- a/Tests/KituraNetTests/BufferListTests.swift
+++ b/Tests/KituraNetTests/BufferListTests.swift
@@ -112,6 +112,6 @@ class BufferListTests: XCTestCase {
         ("testFillMutableData", testFillMutableData),
         ("testFillUnsafeMutablePointer", testFillUnsafeMutablePointer),
         ("testRewind", testRewind),
-        ("testDataAndCount", testDataAndCount),
+        ("testDataAndCount", testDataAndCount)
     ]
 }

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 class ClientE2ETests: KituraNetTest {
 
-    static var allTests : [(String, (ClientE2ETests) -> () throws -> Void)] {
+    static var allTests: [(String, (ClientE2ETests) -> () throws -> Void)] {
         return [
             ("testEphemeralListeningPort", testEphemeralListeningPort),
             ("testErrorRequests", testErrorRequests),
@@ -57,8 +57,7 @@ class ClientE2ETests: KituraNetTest {
                     var data = Data()
                     let count = try response?.readAllData(into: &data)
                     XCTAssertEqual(count, 0, "Result should have been zero bytes, was \(String(describing: count)) bytes")
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 XCTAssertEqual(response?.httpVersionMajor, 1, "HTTP Major code from KituraNet should be 1, was \(String(describing: response?.httpVersionMajor))")
@@ -78,8 +77,7 @@ class ClientE2ETests: KituraNetTest {
                 }
                 expectation.fulfill()
             })
-        },
-        { expectation in
+        }, { expectation in
             self.performRequest("get", path: "/posttest", close: false, callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .OK was \(String(describing: response?.statusCode))")
                 if let connectionHeader = response?.headers["Connection"] {
@@ -134,18 +132,15 @@ class ClientE2ETests: KituraNetTest {
                     XCTAssertEqual(postValue?.count, 12, "Result should have been 12 bytes, was \(String(describing: postValue?.count)) bytes")
                     if  let postValue = postValue {
                         XCTAssertEqual(postValue, "Read 0 bytes")
-                    }
-                    else {
+                    } else {
                         XCTFail("postValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
             })
-        },
-        { expectation in
+        }, { expectation in
             self.performRequest("post", path: "/posttest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -155,16 +150,14 @@ class ClientE2ETests: KituraNetTest {
                     let postValue = String(data: data as Data, encoding: .utf8)
                     if  let postValue = postValue {
                         XCTAssertEqual(postValue, "Read 16 bytes")
-                    }
-                    else {
+                    } else {
                         XCTFail("postValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
-            }) {request in
+            }) { request in
                 request.set(.disableSSLVerification)
                 request.write(from: "A few characters")
             }
@@ -182,18 +175,15 @@ class ClientE2ETests: KituraNetTest {
                     let putValue = String(data: data as Data, encoding: .utf8)
                     if  let putValue = putValue {
                         XCTAssertEqual(putValue, "Read 0 bytes")
-                    }
-                    else {
+                    } else {
                         XCTFail("putValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
             })
-        },
-        { expectation in
+        }, { expectation in
             self.performRequest("put", path: "/puttest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -203,12 +193,10 @@ class ClientE2ETests: KituraNetTest {
                     let postValue = String(data: data as Data, encoding: .utf8)
                     if  let postValue = postValue {
                         XCTAssertEqual(postValue, "Read 16 bytes")
-                    }
-                    else {
+                    } else {
                         XCTFail("postValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
@@ -229,18 +217,15 @@ class ClientE2ETests: KituraNetTest {
                     let patchValue = String(data: data as Data, encoding: .utf8)
                     if  let patchValue = patchValue {
                         XCTAssertEqual(patchValue, "Read 0 bytes")
-                    }
-                    else {
+                    } else {
                         XCTFail("patchValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
             })
-        },
-        { expectation in
+        }, { expectation in
             self.performRequest("patch", path: "/patchtest", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 do {
@@ -250,12 +235,10 @@ class ClientE2ETests: KituraNetTest {
                     let patchValue = String(data: data as Data, encoding: .utf8)
                     if  let patchValue = patchValue {
                         XCTAssertEqual(patchValue, "Read 16 bytes")
-                    }
-                    else {
+                    } else {
                         XCTFail("patchValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
@@ -298,8 +281,7 @@ class ClientE2ETests: KituraNetTest {
                 do {
                     let body = try request.readString()
                     result = "Read \(body?.count ?? 0) bytes"
-                }
-                catch {
+                } catch {
                     print("Error reading body")
                     result = "Read -1 bytes"
                 }
@@ -309,8 +291,7 @@ class ClientE2ETests: KituraNetTest {
                 do {
                     let length = try request.readAllData(into: &body)
                     result = "Read \(length) bytes"
-                }
-                catch {
+                } catch {
                     print("Error reading body")
                     result = "Read -1 bytes"
                 }
@@ -323,8 +304,7 @@ class ClientE2ETests: KituraNetTest {
                 response.headers["Content-Length"] = ["\(result.count)"]
 
                 try response.end(text: result)
-            }
-            catch {
+            } catch {
                 print("Error writing response")
             }
         }
@@ -347,8 +327,7 @@ class ClientE2ETests: KituraNetTest {
 
                 try response.write(from: resultData)
                 try response.end()
-            }
-            catch {
+            } catch {
                 print("Error reading body or writing response")
             }
         }

--- a/Tests/KituraNetTests/ClientRequestTests.swift
+++ b/Tests/KituraNetTests/ClientRequestTests.swift
@@ -140,7 +140,7 @@ class ClientRequestTests: KituraNetTest {
 }
 
 extension ClientRequestTests {
-    static var allTests : [(String, (ClientRequestTests) -> () throws -> Void)] {
+    static var allTests: [(String, (ClientRequestTests) -> () throws -> Void)] {
         return [
             ("testClientRequestWhenInitializedWithValidURL", testClientRequestWhenInitializedWithValidURL),
             ("testClientRequestWhenInitializedWithSimpleSchema",
@@ -154,7 +154,7 @@ extension ClientRequestTests {
             ("testClientRequestSet", testClientRequestSet),
             ("testClientRequestParse", testClientRequestParse),
             ("testClientRequestBasicAuthentcation", testClientRequestBasicAuthentcation),
-            ("testClientRequestSyncBehavior", testClientRequestSyncBehavior),
+            ("testClientRequestSyncBehavior", testClientRequestSyncBehavior)
         ]
     }
 }

--- a/Tests/KituraNetTests/HTTPResponseTests.swift
+++ b/Tests/KituraNetTests/HTTPResponseTests.swift
@@ -20,11 +20,11 @@ import XCTest
 @testable import KituraNet
 
 class HTTPResponseTests: KituraNetTest {
-    static var allTests : [(String, (HTTPResponseTests) -> () throws -> Void)] {
+    static var allTests: [(String, (HTTPResponseTests) -> () throws -> Void)] {
         return [
             ("testContentTypeHeaders", testContentTypeHeaders),
             ("testHeadersContainerHTTPHeaders", testHeadersContainerHTTPHeaders),
-            ("testMultipleWritesToResponse", testMultipleWritesToResponse),
+            ("testMultipleWritesToResponse", testMultipleWritesToResponse)
         ]
     }
 

--- a/Tests/KituraNetTests/HTTPStatusCodeTests.swift
+++ b/Tests/KituraNetTests/HTTPStatusCodeTests.swift
@@ -66,12 +66,12 @@ class HTTPStatusCodeTests: KituraNetTest {
 }
 
 extension HTTPStatusCodeTests {
-    static var allTests : [(String, (HTTPStatusCodeTests) -> () throws -> Void)] {
+    static var allTests: [(String, (HTTPStatusCodeTests) -> () throws -> Void)] {
         return [
             ("testStatusCodeCreation", testStatusCodeCreation),
             ("testInvalidStatusCode", testInvalidStatusCode),
             ("testClassOfStatusCode", testClassOfStatusCode),
-            ("testClassOfEveryValidCode", testClassOfEveryValidCode),
+            ("testClassOfEveryValidCode", testClassOfEveryValidCode)
         ]
     }
 }

--- a/Tests/KituraNetTests/KituraNIOTest.swift
+++ b/Tests/KituraNetTests/KituraNIOTest.swift
@@ -102,14 +102,14 @@ class KituraNetTest: XCTestCase {
             let requestQueue = DispatchQueue(label: "Request queue")
             for (index, asyncTask) in asyncTasks.enumerated() {
                 let expectation = self.expectation(line: line, index: index)
-                requestQueue.async() {
+                requestQueue.async {
                     asyncTask(expectation)
                 }
             }
 
             // wait for timeout or for all created expectations to be fulfilled
             waitExpectation(timeout: 10) { error in
-                XCTAssertNil(error);
+                XCTAssertNil(error)
             }
         } catch {
             XCTFail("Error: \(error)")
@@ -150,8 +150,8 @@ class KituraNetTest: XCTestCase {
                         headers: [String: String]? = nil, requestModifier: ((ClientRequest) -> Void)? = nil) {
 
         var allHeaders = [String: String]()
-        if  let headers = headers  {
-            for  (headerName, headerValue) in headers  {
+        if  let headers = headers {
+            for  (headerName, headerValue) in headers {
                 allHeaders[headerName] = headerValue
             }
         }

--- a/Tests/KituraNetTests/LargePayloadTests.swift
+++ b/Tests/KituraNetTests/LargePayloadTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 class LargePayloadTests: KituraNetTest {
 
-    static var allTests : [(String, (LargePayloadTests) -> () throws -> Void)] {
+    static var allTests: [(String, (LargePayloadTests) -> () throws -> Void)] {
         return [
             ("testLargePosts", testLargePosts),
             ("testLargeGets", testLargeGets)
@@ -52,12 +52,10 @@ class LargePayloadTests: KituraNetTest {
                     let postValue = String(data: data, encoding: .utf8)
                     if  let postValue = postValue {
                         XCTAssertEqual(postValue, expectedResult)
-                    }
-                    else {
+                    } else {
                         XCTFail("postValue's value wasn't an UTF8 string")
                     }
-                }
-                catch {
+                } catch {
                     XCTFail("Failed reading the body of the response")
                 }
                 expectation.fulfill()
@@ -78,13 +76,12 @@ class LargePayloadTests: KituraNetTest {
         })
     }
 
-    private class TestServerDelegate : ServerDelegate {
+    private class TestServerDelegate: ServerDelegate {
 
         func handle(request: ServerRequest, response: ServerResponse) {
             if  request.method.uppercased() == "GET" {
                 handleGet(request: request, response: response)
-            }
-            else {
+            } else {
                 handlePost(request: request, response: response)
             }
         }
@@ -100,8 +97,7 @@ class LargePayloadTests: KituraNetTest {
                 response.headers["Content-Length"] = ["\(payloadData.count)"]
                 try response.write(from: payloadData)
                 try response.end()
-            }
-            catch {
+            } catch {
                 print("Error writing response.")
             }
         }
@@ -115,8 +111,7 @@ class LargePayloadTests: KituraNetTest {
                 response.headers["Content-Length"] = ["\(result.count)"]
 
                 try response.end(text: result)
-            }
-            catch {
+            } catch {
                 print("Error reading body or writing response")
             }
         }

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -23,11 +23,11 @@ import XCTest
 
 class LifecycleListenerTests: KituraNetTest {
 
-    static var allTests : [(String, (LifecycleListenerTests) -> () throws -> Void)] {
+    static var allTests: [(String, (LifecycleListenerTests) -> () throws -> Void)] {
         return [
             ("testLifecycle", testLifecycle),
             ("testLifecycleWithState", testLifecycleWithState),
-            ("testServerFailLifecycle", testServerFailLifecycle),
+            ("testServerFailLifecycle", testServerFailLifecycle)
             //("testFastCGILifecycle", testFastCGILifecycle)
         ]
     }
@@ -50,7 +50,7 @@ class LifecycleListenerTests: KituraNetTest {
             startExpectation.fulfill()
         }
 
-        server.clientConnectionFailed() { error in
+        server.clientConnectionFailed { error in
             XCTFail("A client connection had an error [\(error)]")
         }
 
@@ -150,7 +150,7 @@ class LifecycleListenerTests: KituraNetTest {
         let failedCallbackExpectation = self.expectation(description: "failedCallback")
 
         let server = HTTP.createServer()
-        server.failed(callback: { error in
+        server.failed(callback: { _ in
             failedCallbackExpectation.fulfill()
         })
 

--- a/Tests/KituraNetTests/MiscellaneousTests.swift
+++ b/Tests/KituraNetTests/MiscellaneousTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 class MiscellaneousTests: KituraNetTest {
 
-    static var allTests : [(String, (MiscellaneousTests) -> () throws -> Void)] {
+    static var allTests: [(String, (MiscellaneousTests) -> () throws -> Void)] {
         return [
             ("testEscape", testEscape),
             ("testHeadersContainers", testHeadersContainers)
@@ -46,7 +46,7 @@ class MiscellaneousTests: KituraNetTest {
         var foundContentType = false
 
         for (key, value) in headers {
-            switch(key.lowercased()) {
+            switch key.lowercased() {
             case "content-type":
                 XCTAssertEqual(value.count, 1, "Content-Type didn't have only one value. It had \(value.count) values")
                 XCTAssertEqual(value[0], "text/plain", "Expecting a value of text/plain. Found \(value[0])")

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 class MonitoringTests: KituraNetTest {
 
-    static var allTests : [(String, (MonitoringTests) -> () throws -> Void)] {
+    static var allTests: [(String, (MonitoringTests) -> () throws -> Void)] {
         return [
             ("testStartedFinishedHTTP", testStartedFinishedHTTP)
         ]
@@ -68,7 +68,7 @@ class MonitoringTests: KituraNetTest {
 
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()
-                XCTAssertNil(error);
+                XCTAssertNil(error)
                 Monitor.delegate = nil
             }
         } catch let error {
@@ -97,14 +97,13 @@ class MonitoringTests: KituraNetTest {
             let now = Date()
             if now >= startedTime {
                 finishedExpectation.fulfill()
-            }
-            else {
+            } else {
                 XCTFail("Monitoring finished called before Monitoring started")
             }
         }
     }
 
-    private class TestServerDelegate : ServerDelegate {
+    private class TestServerDelegate: ServerDelegate {
 
         func handle(request: ServerRequest, response: ServerResponse) {
             let payloadData = contentTypesString.data(using: .utf8)!
@@ -113,8 +112,7 @@ class MonitoringTests: KituraNetTest {
                 response.headers["Content-Length"] = ["\(payloadData.count)"]
                 try response.write(from: payloadData)
                 try response.end()
-            }
-            catch {
+            } catch {
                 XCTFail("Error writing response.")
             }
         }

--- a/Tests/KituraNetTests/ParserTests.swift
+++ b/Tests/KituraNetTests/ParserTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import KituraNet
 
 class ParserTests: KituraNetTest {
-    static var allTests : [(String, (ParserTests) -> () throws -> Void)] {
+    static var allTests: [(String, (ParserTests) -> () throws -> Void)] {
         return [
             ("testParseComplexUrl", testParseComplexUrl),
             ("testParserDescription", testParserDescription),

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -30,12 +30,12 @@ func randomNumber(limit: Int) -> Int {
     #endif
 }
 
-class PipeliningTests : KituraNetTest {
+class PipeliningTests: KituraNetTest {
 
-    static var allTests : [(String, (PipeliningTests) -> () throws -> Void)] {
+    static var allTests: [(String, (PipeliningTests) -> () throws -> Void)] {
         return [
             ("testPipelining", testPipelining),
-            ("testPipeliningSpanningPackets", testPipeliningSpanningPackets),
+            ("testPipeliningSpanningPackets", testPipeliningSpanningPackets)
         ]
     }
 
@@ -63,7 +63,7 @@ class PipeliningTests : KituraNetTest {
             }
             .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .connect(host: "localhost", port: server.port!).wait()
-            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .GET,  uri: "/")
+            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET,  uri: "/")
             for _ in 0...4 {
                 clientChannel.write(NIOAny(HTTPClientRequestPart.head(request)), promise: nil)
                 _ = clientChannel.write(NIOAny(HTTPClientRequestPart.end(nil)))
@@ -101,7 +101,7 @@ class PipeliningTests : KituraNetTest {
                 }
                 .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
                 .connect(host: "localhost", port: server.port!).wait()
-            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .POST,  uri: "/")
+            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .POST,  uri: "/")
             for _ in 0...5 {
                 clientChannel.write(NIOAny(HTTPClientRequestPart.head(request)), promise: nil)
                 let buffer = BufferList()
@@ -163,7 +163,7 @@ private class PipelinedRequestsHandler: ChannelInboundHandler {
     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         let request = self.unwrapInboundIn(data)
         switch request {
-        case .head(_):
+        case .head:
             break
         case .body(let buffer):
             let len = buffer.readableBytes
@@ -171,7 +171,7 @@ private class PipelinedRequestsHandler: ChannelInboundHandler {
             if responses == expectedResponses {
                 expectation.fulfill()
             }
-        case .end(_):
+        case .end:
            break
         }
    }

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -25,13 +25,13 @@ import LoggerAPI
 
 class RegressionTests: KituraNetTest {
 
-    static var allTests : [(String, (RegressionTests) -> () throws -> Void)] {
+    static var allTests: [(String, (RegressionTests) -> () throws -> Void)] {
         return [
             ("testIssue1143", testIssue1143),
             ("testServersCollidingOnPort", testServersCollidingOnPort),
             ("testServersSharingPort", testServersSharingPort),
             ("testBadRequest", testBadRequest),
-            ("testBadRequestFollowingGoodRequest", testBadRequestFollowingGoodRequest),
+            ("testBadRequestFollowingGoodRequest", testBadRequestFollowingGoodRequest)
         ]
     }
 
@@ -281,7 +281,7 @@ class RegressionTests: KituraNetTest {
             } catch {
                 Log.error("Failed to connect to port \(port)")
             }
-            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .GET,  uri: "#/")
+            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET,  uri: "#/")
             _ = channel?.write(NIOAny(HTTPClientRequestPart.head(request)))
             _ = channel?.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
         }
@@ -292,13 +292,13 @@ class RegressionTests: KituraNetTest {
             } catch {
                 Log.error("Failed to connect to port \(port)")
             }
-            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .GET,  uri: "/")
+            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET,  uri: "/")
             var httpHeaders = HTTPHeaders()
             httpHeaders.add(name: "Connection", value: "Keep-Alive")
             _ = channel?.write(NIOAny(HTTPClientRequestPart.head(request)))
             _ = channel?.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
             sleep(1) //workaround for an apparent swift-nio issue
-            let request0 = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: .GET,  uri: "#/")
+            let request0 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET,  uri: "#/")
             _ = channel?.write(NIOAny(HTTPClientRequestPart.head(request0)))
             _ = channel?.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
         }
@@ -326,9 +326,9 @@ class HTTPClient: ChannelInboundHandler {
             if header.status == .badRequest && connectionHeaderValue.lowercased() == "close" {
                 expectation.fulfill()
             }
-        case .body(_):
+        case .body:
             break
-        case .end(_):
+        case .end:
            break
         }
     }

--- a/Tests/KituraNetTests/SSLConfig/SSLConfig.swift
+++ b/Tests/KituraNetTests/SSLConfig/SSLConfig.swift
@@ -26,7 +26,7 @@ public struct SSLConfig {
     // MARK: Lifecycle
 
     #if os(Linux)
-    //MARK: For Linux
+    // MARK: For Linux
     /// Initialize an `SSLService.Configuration` instance using a CA certificate file.
     ///
     /// - Parameter caCertificateFilePath: Path to the PEM formatted CA certificate file.
@@ -37,7 +37,7 @@ public struct SSLConfig {
     ///    - Returns:    New `SSLConfig` instance.
     public init(withCACertificateFilePath caCertificateFilePath: String?, usingCertificateFile certificateFilePath: String?, withKeyFile keyFilePath: String? = nil, usingSelfSignedCerts selfSigned: Bool = true, cipherSuite: String? = nil) {
 
-    config = SSLService.Configuration(withCACertificateFilePath: caCertificateFilePath, usingCertificateFile: certificateFilePath, withKeyFile:keyFilePath, usingSelfSignedCerts: selfSigned, cipherSuite: cipherSuite)
+    config = SSLService.Configuration(withCACertificateFilePath: caCertificateFilePath, usingCertificateFile: certificateFilePath, withKeyFile: keyFilePath, usingSelfSignedCerts: selfSigned, cipherSuite: cipherSuite)
     }
 
     /// Initialize an `SSLService.Configuration` instance using a CA certificate directory.
@@ -52,10 +52,10 @@ public struct SSLConfig {
     ///    - Returns: New `SSLConfig` instance.
     public init(withCACertificateDirectory caCertificateDirPath: String?, usingCertificateFile certificateFilePath: String?, withKeyFile keyFilePath: String? = nil, usingSelfSignedCerts selfSigned: Bool = true, cipherSuite: String? = nil) {
 
-    config = SSLService.Configuration(withCACertificateDirectory:caCertificateDirPath, usingCertificateFile: certificateFilePath, withKeyFile: keyFilePath, usingSelfSignedCerts: selfSigned, cipherSuite: cipherSuite)
+    config = SSLService.Configuration(withCACertificateDirectory: caCertificateDirPath, usingCertificateFile: certificateFilePath, withKeyFile: keyFilePath, usingSelfSignedCerts: selfSigned, cipherSuite: cipherSuite)
     }
     #endif // os(Linux)
-    //MARK: For MacOS
+    // MARK: For MacOS
     /// Initialize an `SSLService.Configuration` instance using a certificate chain file.
     ///
     /// *Note:* If using a certificate chain file, the certificates must be in PEM format and must be sorted starting with the subject's certificate (actual client or server certificate), followed by intermediate CA certificates if applicable, and ending at the highest level (root) CA.


### PR DESCRIPTION
This PR enforces Swift style and conventions based on [https://github.com/realm/SwiftLint](url) and violations for following rules has been fixed.

- Closing Brace Spacing
- Closure Spacing
- Colon
- Control Statement
- Empty Enum Arguments
- Empty Parameters
- Empty Parentheses with Trailing Closure
- Identifier Name
- Implicit Getter
- Implicitly Unwrapped Optional
- Mark
- Multiple Closures with Trailing Closure
- Redundant Nil Coalescing
- Redundant Void Return
- Switch and Case Statement Alignment
- Trailing Closure
- Trailing Comma
- Trailing Semicolon
- Trailing Whitespace
- Vertical Whitespace
- Vertical Whitespace Between Cases
- Vertical Whitespace before Closing Braces
- Vertical Whitespace after Opening Braces
- Void Return

Rules Ref: https://github.com/realm/SwiftLint/blob/master/Rules.md



