### PR TITLE
tests: introduce a compiler flag to enable ephemeral ports

### DIFF
--- a/.swift-test-linux
+++ b/.swift-test-linux
@@ -1,0 +1,1 @@
+swift test -Xswiftc -DUSE_EPHEMERAL_PORTS

--- a/.swift-test-macOS
+++ b/.swift-test-macOS
@@ -1,0 +1,1 @@
+swift test -Xswiftc -DUSE_EPHEMERAL_PORTS

--- a/Tests/KituraNetTests/KituraNIOTest.swift
+++ b/Tests/KituraNetTests/KituraNIOTest.swift
@@ -29,6 +29,7 @@ struct KituraNetTestError: Swift.Error {
 class KituraNetTest: XCTestCase {
 
     override class func setUp() {
+#if USE_EPHEMERAL_PORTS
         func shell(_ args: String...) {
             let task = Process()
             task.launchPath = "/usr/bin/env"
@@ -37,6 +38,7 @@ class KituraNetTest: XCTestCase {
             task.waitUntilExit()
         }
         shell("./Tests/KituraNetTests/setup.sh")
+#endif
     }
 
     static let useSSLDefault = true
@@ -103,10 +105,13 @@ class KituraNetTest: XCTestCase {
 
         do {
             self.useSSL = useSSL
-
-            let (server, port) = try startEphemeralServer(delegate, useSSL: useSSL, allowPortReuse: allowPortReuse)
+#if USE_EPHEMERAL_PORTS
+            let (server, ephemeralPort) = try startEphemeralServer(delegate, useSSL: useSSL, allowPortReuse: allowPortReuse)
+            self.port = ephemeralPort
+#else
+            let server: HTTPServer = try startServer(delegate, port: port, useSSL: useSSL, allowPortReuse: allowPortReuse)
             self.port = port
-
+#endif
             defer {
                 server.stop()
             }

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,7 +55,11 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
+#if USE_EPHEMERAL_PORTS
             try server.listen(on: 0)
+#else
+            try server.listen(on: self.port)
+#endif
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -127,7 +131,11 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
+#if USE_EPHEMERAL_PORTS
             try server.listen(on: 0)
+#else
+            try server.listen(on: self.port)
+#endif
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -65,7 +65,11 @@ class MonitoringTests: KituraNetTest {
         }
 
         do {
+#if USE_EPHEMERAL_PORTS
             try server.listen(on: 0)
+#else
+            try server.listen(on: self.port)
+#endif
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()
                 XCTAssertNil(error)


### PR DESCRIPTION
Owing to a limitation in ClientRequest, the use of ephemeral ports needs configuration of the ephemeral port range. This configuration is done using the `sysctl` command on both Linux and macOS. While sysctl appears to be working without sudo permissions on Linux, it needs sudo on macOS. This forces `swift test` to stop at the password prompt. This behaviour change needs to be avoided. This commit makes the use of ephemeral ports optional by introducing a compiler flag called `USE_EPHEMERAL_PORTS`.

To run Kitura-NIO tests with ephemeral ports issue: `swift test -Xswiftc -DUSE_EPHEMERAL_PORTS`

On Travis CI, we could continue using ephemeral ports on both macOS and Linux. For this, the `.swift-test-macOS` and `.swift-test-linux` are added.