### PR TITLE
Add parallel test runs to Travis CI

### DIFF
--- a/.run-tests-parallel
+++ b/.run-tests-parallel
@@ -1,0 +1,1 @@
+swift test -Xswiftc -DUSE_EPHEMERAL_PORTS --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: CUSTOM_TEST_SCRIPT=.run-tests-parallel
     - os: linux
       dist: trusty
       sudo: required
@@ -48,6 +49,7 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+      env: CUSTOM_TEST_SCRIPT=.run-tests-parallel
     - os: osx
       osx_image: xcode10.1
       sudo: required


### PR DESCRIPTION
Related to #128 

With the use of ephemeral ports, we can use the `--parallel` flag from `swift test` to run tests in parallel. I propose we start with only two runs for now - one on Ubuntu and another on macOS. In future, we might want to have all our runs using `--parallel`.