### PR TITLE
HTTPServerRequest: initialize localAddress and remoteAddress lazily

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -398,26 +398,15 @@ public class ClientRequest {
         // Make the HTTP request, the response callbacks will be received on the HTTPClientHandler.
         // We are mostly not running on the event loop. Let's make sure we send the request over the event loop.
         guard let channel = channel else { return }
-        execute(on: channel.eventLoop) {
+        channel.eventLoop.run {
             self.sendRequest(request: request, on: channel)
         }
         waitSemaphore.wait()
 
         // We are now free to close the connection if asked for.
         if closeConnection {
-            execute(on: channel.eventLoop) {
+            channel.eventLoop.run {
                 channel.close(promise: nil)
-            }
-        }
-    }
-
-    /// Executes task on event loop
-    private func execute(on eventLoop: EventLoop, _ task: @escaping () -> Void) {
-        if eventLoop.inEventLoop {
-            task()
-        } else {
-            eventLoop.execute {
-                task()
             }
         }
     }

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -54,18 +54,30 @@ public class HTTPServerRequest: ServerRequest {
 
         self.enableSSL ? url.append("https://") : url.append("http://")
 
+        var localAddress = ""
+        var localAddressPort = UInt16(0)
+
+        do {
+            try ctx.eventLoop.submit {
+                localAddress = HTTPServerRequest.host(socketAddress: self.ctx.localAddress)
+                localAddressPort = self.ctx.localAddress?.port ?? 0
+            }.wait()
+        } catch {
+            Log.error("Unable to get the local address")
+        }
+
         if let hostname = headers["Host"]?.first {
             url.append(hostname)
             if !hostname.contains(":") {
                 url.append(":")
-                url.append(String(describing: self.localAddressPort))
+                url.append(String(describing: localAddressPort))
             }
         } else {
             Log.error("Host header not received")
-            let hostname = self.localAddress
+            let hostname = localAddress
             url.append(hostname == "127.0.0.1" ? "localhost" : hostname)
             url.append(":")
-            url.append(String(describing: self.localAddressPort))
+            url.append(String(describing: localAddressPort))
         }
 
         url.append(_urlString)
@@ -92,9 +104,7 @@ public class HTTPServerRequest: ServerRequest {
     /// HTTP Method of the request.
     public var method: String
 
-    private let localAddress: String
-
-    private let localAddressPort: Int
+    private let ctx: ChannelHandlerContext
 
     private var enableSSL: Bool = false
 
@@ -115,15 +125,13 @@ public class HTTPServerRequest: ServerRequest {
     }
 
     init(ctx: ChannelHandlerContext, requestHead: HTTPRequestHead, enableSSL: Bool) {
+        self.ctx = ctx
         self.headers = HeadersContainer(with: requestHead.headers)
         self.method = requestHead.method.string()
         self.httpVersionMajor = requestHead.version.major
         self.httpVersionMinor = requestHead.version.minor
         self._urlString = requestHead.uri
-        let localAddress = ctx.localAddress
         self.remoteAddress = HTTPServerRequest.host(socketAddress: ctx.remoteAddress)
-        self.localAddress = HTTPServerRequest.host(socketAddress: localAddress)
-        self.localAddressPort = localAddress?.port.map { Int($0) } ?? 0
         self.enableSSL = enableSSL
     }
 


### PR DESCRIPTION
In `HTTPServerRequest` private vars `localAddress` and `localAddressPort` are used only in the implementation of the `urlURL` property. However, they are always initialised in the `HTTPServerRequest` initialiser. We can move their initialisation within the `urlURL` implementation.