### PR TITLE
tests: Use ephemeral ports by default

### DIFF
--- a/.run-tests-parallel
+++ b/.run-tests-parallel
@@ -1,1 +1,1 @@
-swift test -Xswiftc -DUSE_EPHEMERAL_PORTS --parallel
+swift test --parallel

--- a/.swift-test-linux
+++ b/.swift-test-linux
@@ -1,1 +1,0 @@
-swift test -Xswiftc -DUSE_EPHEMERAL_PORTS

--- a/.swift-test-macOS
+++ b/.swift-test-macOS
@@ -1,1 +1,0 @@
-swift test -Xswiftc -DUSE_EPHEMERAL_PORTS

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -21,6 +21,12 @@ import NIOOpenSSL
 import LoggerAPI
 import Dispatch
 
+fileprivate extension Int16 {
+    func toUInt16() -> UInt16 {
+        return UInt16(bitPattern: self)
+    }
+}
+
 /// This class provides a set of low level APIs for issuing HTTP requests to another server.
 public class ClientRequest {
 
@@ -203,8 +209,9 @@ public class ClientRequest {
                 hostName = host
                 self.hostName = host
             case .port(let thePort):
-                port = ":\(thePort)"
-                self.port = Int(thePort)
+                let portNumber = thePort.toUInt16()
+                port = ":\(portNumber)"
+                self.port = Int(portNumber)
             case .path(var thePath):
                 if thePath.first != "/" {
                     thePath = "/" + thePath
@@ -273,7 +280,7 @@ public class ClientRequest {
         }
         options.append(.path(fullPath))
         if let port = url.port {
-            options.append(.port(Int16(port)))
+            options.append(.port(Int16(bitPattern: UInt16(port))))
         }
         if let username = url.user {
             options.append(.username(username))

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,11 +55,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-#if USE_EPHEMERAL_PORTS
             try server.listen(on: 0)
-#else
-            try server.listen(on: self.port)
-#endif
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -131,11 +127,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-#if USE_EPHEMERAL_PORTS
             try server.listen(on: 0)
-#else
-            try server.listen(on: self.port)
-#endif
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -65,11 +65,7 @@ class MonitoringTests: KituraNetTest {
         }
 
         do {
-#if USE_EPHEMERAL_PORTS
             try server.listen(on: 0)
-#else
-            try server.listen(on: self.port)
-#endif
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/setup.sh
+++ b/Tests/KituraNetTests/setup.sh
@@ -1,7 +1,0 @@
-OS=`uname`
-if [ $OS = "Darwin" ]; then
-    sudo sysctl -w net.inet.ip.portrange.first=10000
-    sudo sysctl -w net.inet.ip.portrange.last=20000
-else
-    sudo sysctl -w net.ipv4.ip_local_port_range="10000 20000"
-fi


### PR DESCRIPTION
Instead of restricting the ephemeral port range to accommodate port numbers in an Int16 (a known limitation of `ClientRequest`), we can cast Int16s to UInt16s and vice versa. This removes the need to have the USE_EPHEMERAL_PORTS compiler flag and the script that issues commands to restrict the ephemeral port range.