### PR TITLE
swift 5: silence a warning

### DIFF
--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -123,9 +123,7 @@ class RegressionTests: KituraNetTest {
 
             do {
                 let sharingServer: HTTPServer = try startServer(nil, port: serverPort, useSSL: false, allowPortReuse: true)
-                defer {
-                    sharingServer.stop()
-                }
+                sharingServer.stop()
             } catch {
                 XCTFail("Second server could not share listener port, received: \(error)")
             }


### PR DESCRIPTION
```
Kitura-NIO/Tests/KituraNetTests/RegressionTests.swift:126:17: warning: 'defer' statement before end of scope always executes immediately; replace with 'do' statement to silence this warning
                defer {
                ^~~~~
                do
```