### PR TITLE
tests: use the SWIFT_TEST_ARGS env variable to run parallel tests

### DIFF
--- a/.run-tests-parallel
+++ b/.run-tests-parallel
@@ -1,1 +1,0 @@
-swift test --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: CUSTOM_TEST_SCRIPT=.run-tests-parallel
+      env: SWIFT_TEST_ARGS="--parallel"
     - os: linux
       dist: trusty
       sudo: required
@@ -49,7 +49,7 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
-      env: CUSTOM_TEST_SCRIPT=.run-tests-parallel
+      env: SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode10.1
       sudo: required


### PR DESCRIPTION
With https://github.com/IBM-Swift/Package-Builder/pull/155 we need not maintain a separate script file with a command to run tests in parallel. We can use the `SWIFT_TEST_ARGS` variable instead.