### PR TITLE
travis: install libressl in before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
       env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install libressl ; fi
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:


### PR DESCRIPTION
Kitura-NIO builds need libressl on macOS. The installation was done by Package-Builder until now. However, installing libressl on every IBM-Swift repository build caused increase in build times. The installation step is hence being removed from Package-Builder (PR # 156). Consequently, the installation needs to be done here.