### PR TITLE
macOS: Use the BREW_INSTALL_PACKAGES env var to install libressl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,22 +41,21 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3 BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode9.4
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true CODECOV_ELIGIBLE=true
+      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true CODECOV_ELIGIBLE=true BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode10
       sudo: required
-      env: SWIFT_TEST_ARGS="--parallel"
+      env: SWIFT_TEST_ARGS="--parallel" BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT BREW_INSTALL_PACKAGES="libressl"
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install libressl ; fi
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:


### PR DESCRIPTION
This pull request is a course correction for the changes related to #151 