### PR TITLE
Travis: Run Kitura tests against the current branch

### DIFF
--- a/.kitura-test.sh
+++ b/.kitura-test.sh
@@ -1,0 +1,41 @@
+# Run Kitura-NIO tests
+swift test
+echo ">> Done running tests. Now preparing to run Kitura tests ..."
+
+# Clone Kitura
+echo ">> cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura"
+cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura
+
+# Set KITURA_NIO
+echo ">> export KITURA_NIO=1"
+export KITURA_NIO=1
+
+# Build once
+echo ">> swift build"
+swift build
+
+# Edit package Kitura-NIO to point to the current branch
+echo ">> swift package edit Kitura-NIO --path ../Kitura-NIO"
+swift package edit Kitura-NIO --path ../Kitura-NIO
+echo ">> swift package edit returned $?."
+
+# If the `swift package edit` command failed, exit with the same failure code
+PACKAGE_EDIT_RESULT=$?
+if [[ $PACKAGE_EDIT_RESULT != 0 ]]; then
+    echo ">> Failed to edit the Kitura-NIO dependency."
+    exit $PACKAGE_EDIT_RESULT
+fi
+
+# Run Kitura tests
+echo ">> swift test"
+swift test
+
+# If the tests failed, exit
+TEST_EXIT_CODE=$?
+if [[ $TEST_EXIT_CODE != 0 ]]; then
+    exit $TEST_EXIT_CODE
+fi
+echo ">> Done running Kitura tests."
+
+# Move back to the original build directory. This is needed on macOS builds for the subsequent swiftlint step.
+cd ../Kitura-NIO

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.3
+      env: SWIFT_SNAPSHOT=4.1.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
     - os: linux
       dist: trusty
       sudo: required
@@ -41,7 +41,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3 BREW_INSTALL_PACKAGES="libressl"
+      env: SWIFT_SNAPSHOT=4.0.3 BREW_INSTALL_PACKAGES="libressl" CUSTOM_TEST_SCRIPT=.kitura-test.sh
     - os: osx
       osx_image: xcode9.4
       sudo: required
@@ -53,7 +53,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT BREW_INSTALL_PACKAGES="libressl"
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT BREW_INSTALL_PACKAGES="libressl" CUSTOM_TEST_SCRIPT=.kitura-test.sh
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
Support for running Kitura tests in Travis, while building Kitua-NIO

## Description
Kitura tests could be run on every pull request raised agains Kitura-NIO on Travis. If the base build (Kitura-NIO) passes, we simply clone Kitura, edit the package to point to the current Kitura-NIO branch and run the Kitura tests.

## Motivation and Context
The Kitura-NIO test suite isn't as effective as the Kitura test suite itself, in catching regressions. It is hence essential to have the Kitura tests run on every pull request raised here.