### PR TITLE
Rename package to Kitura-NIO (akin to Kitura-net)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "KituraNet",
+    name: "Kitura-NIO",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
In SwiftPM parlance, Kitura-net's `package name` is `Kitura-net` and the `library name` is `KituraNet`. For Kitura-NIO, the `library name` has been consciously maintained as `KituraNet` and the package name is also `KituraNet`. For the sake of equivalence, it makes sense to change the `package name` here to `Kitura-NIO`.