### PR TITLE
Create Data using String.utf8 instead of NSString.data(using:)

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -317,9 +317,7 @@ public class ClientRequest {
     ///
     /// - Parameter from: The String to be added
     public func write(from string: String) {
-        if let data = string.data(using: .utf8) {
-            write(from: data)
-        }
+        write(from: Data(string.utf8))
     }
 
     /// Add the bytes in a Data struct to the body of the request to be sent
@@ -480,11 +478,9 @@ public class ClientRequest {
             }
     }
 
-    private func createHTTPBasicAuthHeader(username: String, password: String) -> String? {
+    private func createHTTPBasicAuthHeader(username: String, password: String) -> String {
         let authHeader = "\(username):\(password)"
-        guard let data = authHeader.data(using: String.Encoding.utf8) else {
-            return nil
-        }
+        let data = Data(authHeader.utf8)
         return "Basic \(data.base64EncodedString())"
     }
 }

--- a/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServerRequest.swift
@@ -55,7 +55,7 @@ public class FastCGIServerRequest: ServerRequest {
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
-    public var url: Data { return requestUri?.data(using: .utf8) ?? Data() }
+    public var url: Data { return Data((requestUri ?? "").utf8) }
 
     /// The URL from the request as URLComponents
     /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -36,7 +36,7 @@ public class HTTPServerRequest: ServerRequest {
     /// Use 'urlURL' for the full URL
     public var url: Data {
         //The url needs to retain the percent encodings. URL.path doesn't, so we do this.
-        return _urlString.data(using: .utf8) ?? Data()
+        return Data(_urlString.utf8)
     }
 
     @available(*, deprecated, message: "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")


### PR DESCRIPTION
We have `string.data(using:)` to create Data in a handful of places. This will be sub-optimal given that it implicitly goes through NSString, which is currently a known performance bottleneck in Swift 5. 

This is on the lines of https://github.com/IBM-Swift/Kitura/pull/1395