### PR TITLE
Correct the access levels of ClientRequest.callback and HTTPClientHandler properties

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -69,7 +69,7 @@ public class ClientRequest {
     public private(set) var closeConnection = false
 
     /// The callback to receive the response
-    public private(set) var callback: Callback
+    private(set) var callback: Callback
 
     /// The hostname of the remote server
     var hostName: String?

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -585,10 +585,10 @@ class HTTPClientHandler: ChannelInboundHandler {
          self.clientRequest = request
      }
 
-     public typealias InboundIn = HTTPClientResponsePart
+     typealias InboundIn = HTTPClientResponsePart
 
      /// Read the header, body and trailer. Redirection is handled in the trailer case.
-     public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
          let response = self.unwrapInboundIn(data)
          switch response {
          case .head(let header):


### PR DESCRIPTION
`ClientRequest.callback` isn't public as seen [here](https://github.com/IBM-Swift/Kitura-net/blob/master/Sources/KituraNet/ClientRequest.swift#L144). We can make it internal because it's accessed from `HTTPClientHandler`.