### PR TITLE
tests: Rework .kitura-test to use Travis folding functions

### DIFF
--- a/.kitura-test.sh
+++ b/.kitura-test.sh
@@ -1,41 +1,44 @@
 # Run Kitura-NIO tests
+travis_start "swift_test"
+echo ">> Executing Kitura-NIO tests"
 swift test
-echo ">> Done running tests. Now preparing to run Kitura tests ..."
+SWIFT_TEST_STATUS=$?
+travis_end
+if [ $SWIFT_TEST_STATUS -ne 0 ]; then
+  echo ">> swift test command exited with $SWIFT_TEST_STATUS"
+  # Return a non-zero status so that Package-Builder will generate a backtrace
+  return $SWIFT_TEST_STATUS
+fi
 
 # Clone Kitura
-echo ">> cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura"
+set -e
+echo ">> Building Kitura"
+travis_start "swift_build_kitura"
 cd .. && git clone https://github.com/IBM-Swift/Kitura && cd Kitura
 
 # Set KITURA_NIO
-echo ">> export KITURA_NIO=1"
 export KITURA_NIO=1
 
 # Build once
-echo ">> swift build"
 swift build
 
 # Edit package Kitura-NIO to point to the current branch
-echo ">> swift package edit Kitura-NIO --path ../Kitura-NIO"
+echo ">> Editing Kitura package to use latest Kitura-NIO"
 swift package edit Kitura-NIO --path ../Kitura-NIO
-echo ">> swift package edit returned $?."
-
-# If the `swift package edit` command failed, exit with the same failure code
-PACKAGE_EDIT_RESULT=$?
-if [[ $PACKAGE_EDIT_RESULT != 0 ]]; then
-    echo ">> Failed to edit the Kitura-NIO dependency."
-    exit $PACKAGE_EDIT_RESULT
-fi
+travis_end
+set +e
 
 # Run Kitura tests
-echo ">> swift test"
+travis_start "swift_test_kitura"
+echo ">> Executing Kitura tests"
 swift test
-
-# If the tests failed, exit
-TEST_EXIT_CODE=$?
-if [[ $TEST_EXIT_CODE != 0 ]]; then
-    exit $TEST_EXIT_CODE
+SWIFT_TEST_STATUS=$?
+travis_end
+if [ $SWIFT_TEST_STATUS -ne 0 ]; then
+  echo ">> swift test command exited with $SWIFT_TEST_STATUS"
+  # Return a non-zero status so that Package-Builder will generate a backtrace
+  return $SWIFT_TEST_STATUS
 fi
-echo ">> Done running Kitura tests."
 
 # Move back to the original build directory. This is needed on macOS builds for the subsequent swiftlint step.
 cd ../Kitura-NIO


### PR DESCRIPTION
IBM-Swift/Package-Builder#161 added the ability to use Travis's output 'folding' to divide build logs into collapsible timed sections, making it much easier to navigate our build logs (particularly where we run the Kitura tests in addition to the Kitura-NIO tests).

This PR adds sections to the custom test script to produce these sections.  I've also reworked the error handling to ensure that test failures are surfaced (via return code) for backtrace generation.  Here's an example of this in action (with a deliberate crash inserted in the tests): https://travis-ci.org/djones6/Kitura-NIO/builds/489606985

A downside of this change is that `.kitura-test.sh` is now dependent on functions that are defined by Package-Builder, however, I don't think there's any intention of running it outside of this context.