### PR TITLE
Add %-encoding in ClientRequest.init, remove in HTTPServerRequest.init

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -238,7 +238,7 @@ public class ClientRequest {
                 if thePath.first != "/" {
                     thePath = "/" + thePath
                 }
-                path = thePath
+                path = thePath.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed) ?? thePath
                 self.path = path
             case .username(let userName):
                 self.userName = userName

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -126,7 +126,18 @@ public class HTTPServerRequest: ServerRequest {
 
     private var enableSSL: Bool = false
 
-    private var _urlString: String
+    private var rawURLString: String
+
+    private var urlStringPercentEncodingRemoved: String?
+
+    private var _urlString: String {
+        guard let urlStringPercentEncodingRemoved = self.urlStringPercentEncodingRemoved else {
+            let _urlStringPercentEncodingRemoved = rawURLString.removingPercentEncoding ?? rawURLString
+            self.urlStringPercentEncodingRemoved = _urlStringPercentEncodingRemoved
+            return _urlStringPercentEncodingRemoved
+        }
+        return urlStringPercentEncodingRemoved
+    }
 
     private static func host(socketAddress: SocketAddress?) -> String {
         guard let socketAddress = socketAddress else {
@@ -148,7 +159,7 @@ public class HTTPServerRequest: ServerRequest {
         self.method = requestHead.method.string()
         self.httpVersionMajor = requestHead.version.major
         self.httpVersionMinor = requestHead.version.minor
-        self._urlString = requestHead.uri
+        self.rawURLString = requestHead.uri
         self.enableSSL = enableSSL
     }
 

--- a/Tests/KituraNetTests/ClientRequestTests.swift
+++ b/Tests/KituraNetTests/ClientRequestTests.swift
@@ -98,6 +98,20 @@ class ClientRequestTests: KituraNetTest {
         let options = ClientRequest.parse("https://username:password@66o.tech:8080/path?key=value")
         let testRequest = ClientRequest(options: options, callback: testCallback)
         XCTAssertEqual(testRequest.url, "https://username:password@66o.tech:8080/path?key=value")
+
+        let options1: [ClientRequest.Options] = [ .schema("https"),
+                                                  .hostname("66o.tech"),
+                                                  .path("/view/matching?key=\"viewTest\"")
+        ]
+        let testRequest1 = ClientRequest(options: options1, callback: testCallback)
+        XCTAssertEqual(testRequest1.url, "https://66o.tech/view/matching?key=%22viewTest%22")
+
+        let options2: [ClientRequest.Options] = [ .schema("https"),
+                                                  .hostname("66o.tech"),
+                                                  .path("/view/match?key?=value?")
+        ]   
+        let testRequest2 = ClientRequest(options: options2, callback: testCallback)
+        XCTAssertEqual(testRequest2.url, "https://66o.tech/view/match?key?=value?")
     }
 
     func testClientRequestBasicAuthentcation() {


### PR DESCRIPTION
This is related to a test failure in CouchDB: https://github.com/IBM-Swift/Kitura-CouchDB/issues/91

During the initialisation of ClientRequest, the `path` component, which, in `ClientRequest`, includes `query` component, needs to be percent encoded. On the other side, during the initialisation of an HTTPServerRequest, we'd need to remove the percent encoding.

ClientRequest.Options.path includes the fragment, path and query components. The only character which is permissible in a fragment and a query but not in a path is `?`. To avoid further parsing here, we could go with percent-encoding a `?` in the path string too.

**A word on encoding `?`**
This does not pertain to the `?` as in: `https://66o.tech/path?q=v`. This pertains to a `?` as in: `https://66o.tech/pa?th?q=?v` which after %-encoding will become `https://66o.tech/pa%3Fth?q=%3Fv`, though `https://66o.tech/pa%3Fth?q=?v` is permissible per the [definition of NSCharacterSet.urlQueryAllowed](https://github.com/apple/swift-corelibs-foundation/blob/b23dc8e249987442811e9e0097c326d7083784ac/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c#L36).

In the proposed change, the `?` character will not be percent-encoded in the path (fragment, path and query), though it should be encoded in the "path". I'm assuming that paths like "/this?path" are rare in occurrence. Percent encoding '?' will make parsing ClientRequest.path all the more complicated and we may want to avoid it until it is explicitly asked for. 

The fact that `ClientRequest.Options.path` includes path and query is a design weakness in this context.

Other components like `host` and `user` may also be percent-encoded, but are those cases really common?