### PR TITLE
Close channels if errors reach the last handler

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -653,6 +653,7 @@ class HTTPClientHandler: ChannelInboundHandler {
 
      func errorCaught(ctx: ChannelHandlerContext, error: Error) {
          // No errors to handle, simply close the channel
+         Log.error("ClientRequest: Error \(error) was received. The connection will be closed because we are neither handling this error nor can it be propagated.")
          ctx.close(promise: nil)
      }
 }

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -650,4 +650,9 @@ class HTTPClientHandler: ChannelInboundHandler {
             }
          }
      }
+
+     func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+         // No errors to handle, simply close the channel
+         ctx.close(promise: nil)
+     }
 }

--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -134,6 +134,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler {
             message = "No service has been registered for the path \(target)"
         default:
             // Don't handle any other errors, including `HTTPParserError`s
+            ctx.close(promise: nil)
             return
         }
 

--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -134,6 +134,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler {
             message = "No service has been registered for the path \(target)"
         default:
             // Don't handle any other errors, including `HTTPParserError`s
+            Log.error("HTTPServer: Error \(error) was received. The connection will be closed because we are neither handling this error nor can it be propagated further.")
             ctx.close(promise: nil)
             return
         }

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -175,4 +175,8 @@ private class PipelinedRequestsHandler: ChannelInboundHandler {
            break
         }
    }
+
+   func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+       ctx.close(promise: nil)
+   }
 }

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -330,4 +330,8 @@ class HTTPClient: ChannelInboundHandler {
            break
         }
     }
+
+    func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+        ctx.close(promise: nil)
+    }
 }


### PR DESCRIPTION
Motivation

This is related to issue #173 If an HTTP error is encountered in the HTTPServer, it is essential that we close the connection after a possible handling of the error. As the issue describes it, this is crucial in the error reaches the last handler of the pipeline and none of the previous handlers were able to handle it. `HTTPRequestHandler` and `HTTPClientHandler` are final handlers of an HTTP server pipeline and an HTTP client pipeline respectively. `HTTPRequestHandler` does handle some errors. We make sure the connection is closed only after the error response is sent back. `HTTPClientHandler` does not do any error handling, so we just close the connection there.