### PR TITLE
Revert "Add support for WebSocket protocol extensions"

### DIFF
--- a/Sources/KituraNet/ConnectionUpgrader.swift
+++ b/Sources/KituraNet/ConnectionUpgrader.swift
@@ -42,18 +42,12 @@ public struct ConnectionUpgrader {
 }
 
 public protocol ProtocolHandlerFactory {
-    // Name of the protocol
+    //Name of the protocol
     var name: String { get }
 
-    // Supplies an NIO channel handler for the protocol. Every upgrade will return a single handler.
+    //Supplies an NIO channel handler for the protocol. Every upgrade will return a single handler.
     func handler(for request: ServerRequest) -> ChannelHandler
 
-    // Checks if a service is available/registered at the given URI
+    //Checks if a service is available/registered at the given URI
     func isServiceRegistered(at path: String) -> Bool
-
-    // Specially included for the WebSocket protocol. This returns an array of handlers of all enabled extensions.
-    func extensionHandlers(header: String) -> [ChannelHandler]
-
-    // Specially included for the WebSocket protocol. This runs the negotiation handshake logic for enabled extensions.
-    func negotiate(header: String) -> String
 }

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -111,9 +111,6 @@ public class HTTPServer: Server {
         if let key =  head.headers["Sec-WebSocket-Key"].first {
             headers.add(name: "Sec-WebSocket-Key", value: key)
         }
-        if let _extension = head.headers["Sec-WebSocket-Extensions"].first {
-            headers.add(name: "Sec-WebSocket-Extensions", value: webSocketHandlerFactory.negotiate(header: _extension))
-        }
         return headers
     }
 
@@ -122,16 +119,7 @@ public class HTTPServer: Server {
         guard let ctx = self.ctx else { fatalError("Cannot create ServerRequest") }
         ///TODO: Handle secure upgrade request ("wss://")
         let serverRequest = HTTPServerRequest(ctx: ctx, requestHead: request, enableSSL: false)
-        let websocketConnectionHandler = webSocketHandlerFactory.handler(for: serverRequest)
-        let future = ctx.channel.pipeline.add(handler: websocketConnectionHandler)
-        if let _extensions = request.headers["Sec-WebSocket-Extensions"].first {
-            for handler in webSocketHandlerFactory.extensionHandlers(header: _extensions) {
-                _ = future.then {
-                    ctx.channel.pipeline.add(handler: handler, before: websocketConnectionHandler)
-                }
-            }
-        }
-        return future
+        return ctx.channel.pipeline.add(handler: webSocketHandlerFactory.handler(for: serverRequest))
     }
 
     private typealias ShouldUpgradeFunction = (HTTPRequestHead) -> HTTPHeaders?


### PR DESCRIPTION
This reverts commit 0452ad8232a2601902b43fd357e58ec1d9c82016.

This change 0452ad8232a2601902b43fd357e58ec1d9c82016 will break the `websocket-nio` branch of Kitura-Websocket before 
https://github.com/IBM-Swift/Kitura-WebSocket/pull/81 is tagged. We'd like to keep it untagged for now. However, two crucial fixes #171 and #172 need to be tagged for `Kitura-CouchDb` testing.

After considering different options, I'm going ahead with the awkward option of reverting this change, tagging Kitura-NIO and then reverting the revert. Apologies for this mess. We need better release planning for the future. 