### PR TITLE
Don't log error messages for closed channels

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -133,8 +133,8 @@ internal class HTTPRequestHandler: ChannelInboundHandler {
             let target = server.latestWebSocketURI ?? "/<unknown>"
             message = "No service has been registered for the path \(target)"
         default:
-            // Don't handle any other errors, including `HTTPParserError`s
-            Log.error("HTTPServer: Error \(error) was received. The connection will be closed because we are neither handling this error nor can it be propagated further.")
+            // Don't handle any other errors, including `HTTPParserError`s.
+            // We could log an error message here.
             ctx.close(promise: nil)
             return
         }


### PR DESCRIPTION
Commit c8a8b1465afd63c90b465164640a60b67e05399c closes channels when a abrupt connection closure from the client is detected, via a read system call failure. Before closing the connection we log an error message. However, in commit 309a6d1638d224f97f76899cd10df2f11aeeaff9 we took a conscious decision to not log error messages when a closed channel was detected. These commits mutually conflict each other in a situation where a connection drop has been detected. I propose we don't log any errors or warnings for now.