### PR TITLE
Pipelining tests: sort responses before comparison

### DIFF
--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -168,7 +168,7 @@ private class PipelinedRequestsHandler: ChannelInboundHandler {
         case .body(let buffer):
             let len = buffer.readableBytes
             responses.append(buffer.getString(at: 0, length: len)!)
-            if responses == expectedResponses {
+            if responses.count == expectedResponses.count && responses.sorted() == expectedResponses {
                 expectation.fulfill()
             }
         case .end:


### PR DESCRIPTION
A lot of intermittent failures are being seen with the pipelining tests on Travis. The failures are not reproducible locally. This commit tries to reduce the likelihood of failures by sorting the received responses before comparing them with the expected responses. This is to take care of cases where we might receive responses in an order different from the requests made.