### PR TITLE
Send error responses for websocket upgrade errors

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -133,11 +133,10 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
             if let upgradeError = error as? NIOWebSocketUpgradeError, upgradeError == .unsupportedWebSocketTarget {
                 let target = server.latestWebSocketURI ?? "/<unknown>"
                 message = "No service has been registered for the path \(target)"
+            } else {
+                context.close(promise: nil)
                 return
             }
-            // TODO: Do we log an error message here?
-            context.close(promise: nil)
-            return
         }
 
         do {


### PR DESCRIPTION
While rebasing on NIO2, a wrong refactor of `HTTPRequestHandler.errorCaught` resulted in some test failures on Kitura-WebSocket. Correcting that here.