### PR TITLE
Handle Host header values with port number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=swift:5.0-xenial DOCKER_PRIVILEGED=true CUSTOM_TEST_SCRIPT=.kitura-test.sh
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=swift:5.0-xenial DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel"
     - os: linux
       dist: xenial
@@ -34,6 +39,11 @@ matrix:
       osx_image: xcode10.2
       sudo: required
       env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+    - os: osx
+      osx_image: xcode10.2
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT CUSTOM_TEST_SCRIPT=.kitura-test.sh
+
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -130,7 +130,8 @@ public class HTTPServerRequest: ServerRequest {
         }
 
         if let hostname = headers["Host"]?.first {
-            _urlComponents?.host = hostname
+            // Handle Host header values of the kind "localhost:8080"
+            _urlComponents?.host = String(hostname.split(separator: ":")[0])
         } else {
             Log.error("Host header not received")
             let hostname = localAddress

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -265,10 +265,11 @@ class ClientE2ETests: KituraNetTest {
         let delegate = TestURLDelegate()
         performServerTest(delegate, socketType: .tcp) { expectation in
             delegate.port = self.port
-            self.performRequest("post", path: ClientE2ETests.urlPath, callback: {response in
+            let headers = ["Host": "localhost:8080"]
+            self.performRequest("post", path: ClientE2ETests.urlPath, callback: { response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
-            })
+            }, headers: headers)
         }
     }
 
@@ -391,6 +392,7 @@ class ClientE2ETests: KituraNetTest {
         var port = 0
 
         func handle(request: ServerRequest, response: ServerResponse) {
+            XCTAssertEqual(request.urlURL.host, "localhost")
             XCTAssertEqual(request.httpVersionMajor, 1, "HTTP Major code from KituraNet should be 1, was \(String(describing: request.httpVersionMajor))")
             XCTAssertEqual(request.httpVersionMinor, 1, "HTTP Minor code from KituraNet should be 1, was \(String(describing: request.httpVersionMinor))")
             XCTAssertEqual(request.urlURL.path, urlPath, "Path in request.urlURL wasn't \(urlPath), it was \(request.urlURL.path)")


### PR DESCRIPTION
Sometimes the value of the Host header could be of the type "localhost:8080". We've been using URLComponents to fabricate the URL pertaining to an HTTPServerRequest. In cases where, the Host
header includes the port number, we'll have to pick up only the host name and ignore the port number.

This is fixes an issue seen in tests for `RuntimeTools/SwiftMetrics`