### PR TITLE
[kitura-nio-1.0] Cherry-pick PR#193

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=4.0.3
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.3 CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=4.1.3
     - os: linux
       dist: trusty
       sudo: required
@@ -42,7 +42,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3 BREW_INSTALL_PACKAGES="libressl" CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=4.0.3 BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode9.4
       sudo: required
@@ -54,7 +54,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT BREW_INSTALL_PACKAGES="libressl" CUSTOM_TEST_SCRIPT=.kitura-test.sh
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT BREW_INSTALL_PACKAGES="libressl"
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 branches:
   only:
     - master
+    - kitura-nio-1.0
     - /^issue.*$/
 
 # the matrix of builds should cover each combination of Swift version

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -69,7 +69,8 @@ public class HTTPServerRequest: ServerRequest {
         }
 
         if let hostname = headers["Host"]?.first {
-            _urlComponents?.host = hostname
+            // Handle Host header values of the kind "localhost:8080"
+            _urlComponents?.host = String(hostname.split(separator: ":")[0])
         } else {
             Log.error("Host header not received")
             let hostname = localAddress

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -265,10 +265,11 @@ class ClientE2ETests: KituraNetTest {
         let delegate = TestURLDelegate()
         performServerTest(delegate) { expectation in
             delegate.port = self.port
-            self.performRequest("post", path: ClientE2ETests.urlPath, callback: {response in
+            let headers = ["Host": "localhost:8080"]
+            self.performRequest("post", path: ClientE2ETests.urlPath, callback: { response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
-            })
+            }, headers: headers)
         }
     }
 
@@ -391,6 +392,7 @@ class ClientE2ETests: KituraNetTest {
         var port = 0
 
         func handle(request: ServerRequest, response: ServerResponse) {
+            XCTAssertEqual(request.urlURL.host, "localhost")
             XCTAssertEqual(request.httpVersionMajor, 1, "HTTP Major code from KituraNet should be 1, was \(String(describing: request.httpVersionMajor))")
             XCTAssertEqual(request.httpVersionMinor, 1, "HTTP Minor code from KituraNet should be 1, was \(String(describing: request.httpVersionMinor))")
             XCTAssertEqual(request.urlURL.path, urlPath, "Path in request.urlURL wasn't \(urlPath), it was \(request.urlURL.path)")


### PR DESCRIPTION
Sometimes the value of the Host header could be of the type
"localhost:8080". We've been using URLComponents to fabricate the
URL pertaining to an HTTPServerRequest. In cases where, the Host
header includes the port number, we'll have to pick up only the
host name and ignore the port number.