### PR TITLE
Do away with using URLComponents for urlURL

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -329,7 +329,11 @@ public class ClientRequest {
                 if thePath.first != "/" {
                     thePath = "/" + thePath
                 }
-                path = thePath.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed) ?? thePath
+                if thePath.contains("%") == false {
+                    path = thePath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? thePath
+                } else {
+                    path = thePath
+                }
                 self.path = path
             case .username(let userName):
                 self.userName = userName

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -80,6 +80,8 @@ public class ClientRequest {
      */
     public private(set) var url: String = ""
 
+    private var percentEncodedURL: String = ""
+
     /**
      The HTTP method (i.e. GET, POST, PUT, DELETE) for the request.
 
@@ -226,14 +228,30 @@ public class ClientRequest {
         case useHTTP2
     }
 
+    private func percentEncode(_ url: String) -> String {
+        var _url = url
+        let isPercentEncoded = _url.contains("%") && URL(string: _url) != nil
+        if !isPercentEncoded {
+            _url = _url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? _url
+        }
+        return _url
+    }
+
     /// Initializes a `ClientRequest` instance
     ///
     /// - Parameter url: url for the request
     /// - Parameter callback: The closure of type `Callback` to be used for the callback.
     init(url: String, callback: @escaping Callback) {
+        self.callback = callback
         self.url = url
-        let url = URL(string: url)!
+        self.percentEncodedURL = percentEncode(url)
 
+        if let url = URL(string: self.percentEncodedURL) {
+            initialize(url)
+        }
+    }
+
+    private func initialize(_ url: URL) {
         if let host = url.host {
             self.hostName = host
         }
@@ -257,7 +275,6 @@ public class ClientRequest {
         if let password = url.password {
             self.password = password
         }
-        self.callback = callback
     }
 
     /**
@@ -329,11 +346,7 @@ public class ClientRequest {
                 if thePath.first != "/" {
                     thePath = "/" + thePath
                 }
-                if thePath.contains("%") == false {
-                    path = thePath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? thePath
-                } else {
-                    path = thePath
-                }
+                path = thePath
                 self.path = path
             case .username(let userName):
                 self.userName = userName
@@ -352,8 +365,8 @@ public class ClientRequest {
         }
 
         //the url string
-        url = "\(theSchema)\(authenticationClause)\(hostName)\(port)\(path)"
-
+        self.url = "\(theSchema)\(authenticationClause)\(hostName)\(port)\(path)"
+        self.percentEncodedURL = percentEncode(self.url)
     }
 
     /**
@@ -524,7 +537,7 @@ public class ClientRequest {
         var isHTTPS = false
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        if (URL(string: url)?.scheme)! == "https" {
+        if (URL(string: percentEncodedURL)?.scheme)! == "https" {
            isHTTPS = true
            self.sslConfig = TLSConfiguration.forClient(certificateVerification: .none)
         }
@@ -535,7 +548,7 @@ public class ClientRequest {
             initializeClientBootstrap(eventLoopGroup: group)
         }
 
-        let hostName = URL(string: url)?.host ?? "" //TODO: what could be the failure path here
+        let hostName = URL(string: percentEncodedURL)?.host ?? "" //TODO: what could be the failure path here
         if self.headers["Host"] == nil {
            self.headers["Host"] = hostName
         }

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -265,7 +265,7 @@ class ClientE2ETests: KituraNetTest {
         let delegate = TestURLDelegate()
         performServerTest(delegate, socketType: .tcp) { expectation in
             delegate.port = self.port
-            let headers = ["Host": "localhost:8080"]
+            let headers = ["Host": "localhost:\(self.port)"]
             self.performRequest("post", path: ClientE2ETests.urlPath, callback: { response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")
                 expectation.fulfill()

--- a/Tests/KituraNetTests/ClientRequestTests.swift
+++ b/Tests/KituraNetTests/ClientRequestTests.swift
@@ -104,7 +104,7 @@ class ClientRequestTests: KituraNetTest {
                                                   .path("/view/matching?key=\"viewTest\"")
         ]
         let testRequest1 = ClientRequest(options: options1, callback: testCallback)
-        XCTAssertEqual(testRequest1.url, "https://66o.tech/view/matching?key=%22viewTest%22")
+        XCTAssertEqual(testRequest1.url, "https://66o.tech/view/matching?key=\"viewTest\"")
 
         let options2: [ClientRequest.Options] = [ .schema("https"),
                                                   .hostname("66o.tech"),


### PR DESCRIPTION
`HTTPServerRequest.urlURL` is currently built using `URLComponents`. Though
convenient, this approach has proven to be convoluted because of percent
encoding restrictions. The alternative is to fall back to building a URL String
, something that we did before adopting URLComponents. We can chose to keep
the percent encoding in HTTPServerRequest.

An additional change is in the initializer of ClientRequest. Though we need
to add percent encoding wherever necessary, we should not percent encode
an percent-encoded path.