### PR TITLE
Support WebSocket URIs with query parameters

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -131,7 +131,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
         default:
             // Handle only NIOWebSocketUpgradeError here, nothing else
             if let upgradeError = error as? NIOWebSocketUpgradeError, upgradeError == .unsupportedWebSocketTarget {
-                let target = server.latestWebSocketURI ?? "/<unknown>"
+                let target = server.latestWebSocketURI
                 message = "No service has been registered for the path \(target)"
             } else {
                 context.close(promise: nil)


### PR DESCRIPTION
On receiving a WebSocket upgrade request, the WebSocketUpgrader first checks if
a WebSocket service has been registered at the requested URI. If not, the
upgrade fails. It may so happen that for a WebSocket service registered at a
URL like `/ws`, a WebSocket client might send related query params, example,
`/ws?p1=q1&p2=q2`. To check if a service is registered at such a URI, it is
essential to strip off the query params.