### PR TITLE
Do not send back an empty header during Websocket upgrade.

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -179,7 +179,11 @@ public class HTTPServer: Server {
             headers.add(name: "Sec-WebSocket-Key", value: key)
         }
         if let _extension = head.headers["Sec-WebSocket-Extensions"].first {
-            headers.add(name: "Sec-WebSocket-Extensions", value: webSocketHandlerFactory.negotiate(header: _extension))
+            let responseExtensions = webSocketHandlerFactory.negotiate(header: _extension)
+            // A Safari bug causes the connection to be dropped if an empty header is sent
+            if !responseExtensions.isEmpty {
+                headers.add(name: "Sec-WebSocket-Extensions", value: responseExtensions)
+            }
         }
         return channel.eventLoop.makeSucceededFuture(headers)
     }


### PR DESCRIPTION
This fixes https://github.com/IBM-Swift/Kitura-WebSocket-NIO/issues/23

Local testing shows that this allows Safari on iOS 11 or OS 10.14.4 to connect to Kitura-Websocket-NIO.