### PR TITLE
Allow Kitura-NIO to only listen on one network address

### DIFF
--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -59,7 +59,7 @@ public class FastCGIServer: Server {
     /// - Parameter on: port number for new connections
     /// - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this
     ///             server will listen on all interfaces.
-    public func listen(on port: Int, address: String?) throws {
+    public func listen(on port: Int, address: String? = nil) throws {
         fatalError("FastCGI is not implemented yet.")
     }
 
@@ -71,7 +71,7 @@ public class FastCGIServer: Server {
     /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
     ///
     /// - Returns: a new `FastCGIServer` instance
-    public static func listen(on port: Int, address: String?, delegate: ServerDelegate?) throws -> FastCGIServer {
+    public static func listen(on port: Int, address: String? = nil, delegate: ServerDelegate?) throws -> FastCGIServer {
         fatalError("FastCGI not implemented yet.")
     }
 

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -29,6 +29,9 @@ public class FastCGIServer: Server {
     /// Port number for listening for new connections
     public private(set) var port: Int?
 
+    /// Has the same meaning as in `getaddrinfo()`.
+    public private(set) var node: String?
+
     /// A server state.
     public private(set) var state: ServerState = .unknown
 
@@ -53,8 +56,28 @@ public class FastCGIServer: Server {
     /// Listens for connections on a socket
     ///
     /// - Parameter on: port number for new connections
+    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    public func listen(on port: Int, node: String?) throws {
+        fatalError("FastCGI is not implemented yet.")
+    }
+
+    /// Listens for connections on a socket
+    ///
+    /// - Parameter on: port number for new connections
+    @available(*, deprecated, message: "use 'listen(on:node) throws' instead")
     public func listen(on port: Int) throws {
         fatalError("FastCGI is not implemented yet.")
+    }
+
+    /// Static method to create a new `FastCGIServer` and have it listen for conenctions
+    ///
+    /// - Parameter on: port number for accepting new connections
+    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
+    ///
+    /// - Returns: a new `FastCGIServer` instance
+    public static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> FastCGIServer {
+        fatalError("FastCGI not implemented yet.")
     }
 
     /// Static method to create a new `FastCGIServer` and have it listen for conenctions
@@ -63,6 +86,7 @@ public class FastCGIServer: Server {
     /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
     ///
     /// - Returns: a new `FastCGIServer` instance
+    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' instead")
     public static func listen(on port: Int, delegate: ServerDelegate?) throws -> FastCGIServer {
         fatalError("FastCGI not implemented yet.")
     }

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -29,8 +29,8 @@ public class FastCGIServer: Server {
     /// Port number for listening for new connections
     public private(set) var port: Int?
 
-    /// Has the same meaning as in `getaddrinfo()`.
-    public private(set) var node: String?
+    /// Has the same meaning as node in `getaddrinfo()`.
+    public private(set) var address: String?
 
     /// A server state.
     public private(set) var state: ServerState = .unknown
@@ -56,38 +56,19 @@ public class FastCGIServer: Server {
     /// Listens for connections on a socket
     ///
     /// - Parameter on: port number for new connections
-    /// - Parameter node: has the same meaning as in `getaddrinfo()`
-    public func listen(on port: Int, node: String?) throws {
-        fatalError("FastCGI is not implemented yet.")
-    }
-
-    /// Listens for connections on a socket
-    ///
-    /// - Parameter on: port number for new connections
-    @available(*, deprecated, message: "use 'listen(on:node) throws' instead")
-    public func listen(on port: Int) throws {
+    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    public func listen(on port: Int, address: String?) throws {
         fatalError("FastCGI is not implemented yet.")
     }
 
     /// Static method to create a new `FastCGIServer` and have it listen for conenctions
     ///
     /// - Parameter on: port number for accepting new connections
-    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
     /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
     ///
     /// - Returns: a new `FastCGIServer` instance
-    public static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> FastCGIServer {
-        fatalError("FastCGI not implemented yet.")
-    }
-
-    /// Static method to create a new `FastCGIServer` and have it listen for conenctions
-    ///
-    /// - Parameter on: port number for accepting new connections
-    /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
-    ///
-    /// - Returns: a new `FastCGIServer` instance
-    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' instead")
-    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> FastCGIServer {
+    public static func listen(on port: Int, address: String?, delegate: ServerDelegate?) throws -> FastCGIServer {
         fatalError("FastCGI not implemented yet.")
     }
 

--- a/Sources/KituraNet/FastCGI/FastCGIServer.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIServer.swift
@@ -29,7 +29,8 @@ public class FastCGIServer: Server {
     /// Port number for listening for new connections
     public private(set) var port: Int?
 
-    /// Has the same meaning as node in `getaddrinfo()`.
+    /// The address of a network interface to listen on, for example "localhost". The default is nil,
+    /// which listens for connections on all interfaces.
     public private(set) var address: String?
 
     /// A server state.
@@ -56,7 +57,8 @@ public class FastCGIServer: Server {
     /// Listens for connections on a socket
     ///
     /// - Parameter on: port number for new connections
-    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    /// - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this
+    ///             server will listen on all interfaces.
     public func listen(on port: Int, address: String?) throws {
         fatalError("FastCGI is not implemented yet.")
     }
@@ -64,7 +66,8 @@ public class FastCGIServer: Server {
     /// Static method to create a new `FastCGIServer` and have it listen for conenctions
     ///
     /// - Parameter on: port number for accepting new connections
-    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    /// - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this
+    ///             server will listen on all interfaces.
     /// - Parameter delegate: the delegate handler for FastCGI/HTTP connections
     ///
     /// - Returns: a new `FastCGIServer` instance

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -269,7 +269,7 @@ public class HTTPServer: Server {
      - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this server
                           will listen on all interfaces.
      */
-    public func listen(on port: Int, address: String?) throws {
+    public func listen(on port: Int, address: String? = nil) throws {
         self.port = port
         self.address = address
         try listen(.tcp(port, address))
@@ -377,7 +377,7 @@ public class HTTPServer: Server {
 
      - Returns: A new instance of a `HTTPServer`.
     */
-    public static func listen(on port: Int, address: String?, delegate: ServerDelegate?) throws -> ServerType {
+    public static func listen(on port: Int, address: String? = nil, delegate: ServerDelegate?) throws -> ServerType {
         let server = HTTP.createServer()
         server.delegate = delegate
         try server.listen(on: port, address: address)

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -58,7 +58,8 @@ public class HTTPServer: Server {
     /// The TCP port on which this server listens for new connections. If `nil`, this server does not listen on a TCP socket.
     public private(set) var port: Int?
 
-    /// Has the same meaning as node in `getaddrinfo()`.
+    /// The address of a network interface to listen on, for example "localhost". The default is nil,
+    /// which listens for connections on all interfaces.
     public private(set) var address: String?
 
     /// The Unix domain socket path on which this server listens for new connections. If `nil`, this server does not listen on a Unix socket.
@@ -265,7 +266,8 @@ public class HTTPServer: Server {
      ````
 
      - Parameter on: Port number for new connections, e.g. 8080
-     - Parameter address: has the same meaning as node in `getaddrinfo()`
+     - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this server
+                          will listen on all interfaces.
      */
     public func listen(on port: Int, address: String?) throws {
         self.port = port
@@ -369,7 +371,8 @@ public class HTTPServer: Server {
      ````
 
      - Parameter on: Port number for accepting new connections.
-     - Parameter address: has the same meaning as node in `getaddrinfo()`
+     - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this server
+                 will listen on all interfaces.
      - Parameter delegate: The delegate handler for HTTP connections.
 
      - Returns: A new instance of a `HTTPServer`.

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -58,6 +58,9 @@ public class HTTPServer: Server {
     /// The TCP port on which this server listens for new connections. If `nil`, this server does not listen on a TCP socket.
     public private(set) var port: Int?
 
+    /// Has the same meaning as in `getaddrinfo()`.
+    public private(set) var node: String?
+
     /// The Unix domain socket path on which this server listens for new connections. If `nil`, this server does not listen on a Unix socket.
     public private(set) var unixDomainSocketPath: String?
 
@@ -232,8 +235,8 @@ public class HTTPServer: Server {
 
     // Sockets could either be TCP/IP sockets or Unix domain sockets
     private enum SocketType {
-        // An TCP/IP socket has an associated port number
-        case tcp(Int)
+        // An TCP/IP socket has an associated port number and optional node value
+        case tcp(Int, String?)
         // A unix domain socket has an associated filename
         case unix(String)
     }
@@ -258,14 +261,21 @@ public class HTTPServer: Server {
 
      ### Usage Example: ###
      ````swift
-     try server.listen(on: 8080)
+     try server.listen(on: 8080, node: "localhost")
      ````
 
      - Parameter on: Port number for new connections, e.g. 8080
-    */
-    public func listen(on port: Int) throws {
+     - Parameter node: has the same meaning as in `getaddrinfo()`
+     */
+    public func listen(on port: Int, node: String?) throws {
         self.port = port
-        try listen(.tcp(port))
+        self.node = node
+        try listen(.tcp(port, node))
+    }
+
+    @available(*, deprecated, message: "use 'listen(on:node) throws' instead")
+    public func listen(on port: Int) throws {
+        try listen(on: port, node: nil)
     }
 
     private func listen(_ socket: SocketType) throws {
@@ -310,8 +320,8 @@ public class HTTPServer: Server {
         let listenerDescription: String
         do {
             switch socket {
-            case SocketType.tcp(let port):
-                serverChannel = try bootstrap.bind(host: "0.0.0.0", port: port).wait()
+            case SocketType.tcp(let port, let node):
+                serverChannel = try bootstrap.bind(host: node ?? "0.0.0.0", port: port).wait()
                 self.port = serverChannel?.localAddress?.port.map { Int($0) }
                 listenerDescription = "port \(self.port ?? port)"
             case SocketType.unix(let unixDomainSocketPath):
@@ -360,19 +370,25 @@ public class HTTPServer: Server {
 
      ### Usage Example: ###
      ````swift
-     let server = HTTPServer.listen(on: 8080, delegate: self)
+     let server = HTTPServer.listen(on: 8080, node: "localhost", delegate: self)
      ````
 
      - Parameter on: Port number for accepting new connections.
+     - Parameter node: has the same meaning as in `getaddrinfo()`
      - Parameter delegate: The delegate handler for HTTP connections.
 
      - Returns: A new instance of a `HTTPServer`.
     */
-    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType {
+    public static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> ServerType {
         let server = HTTP.createServer()
         server.delegate = delegate
-        try server.listen(on: port)
+        try server.listen(on: port, node: node)
         return server
+    }
+
+    @available(*, deprecated, message: "use 'listen(on:node:delagate) throws' instead")
+    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType {
+        return try listen(on: port, node: nil, delegate: delegate)
     }
 
     /**

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -26,13 +26,32 @@ public protocol Server {
     /// Port number for listening for new connections.
     var port: Int? { get }
 
+    /// Has the same meaning as in `getaddrinfo()`.
+    var node: String? { get }
+
     /// A server state.
     var state: ServerState { get }
 
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
+    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    func listen(on port: Int, node: String?) throws
+
+    /// Listen for connections on a socket.
+    ///
+    /// - Parameter on: port number for new connections (eg. 8080)
+    @available(*, deprecated, message: "use 'listen(on:node) throws' with instead")
     func listen(on port: Int) throws
+
+    /// Static method to create a new Server and have it listen for connections.
+    ///
+    /// - Parameter on: port number for accepting new connections
+    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    /// - Parameter delegate: the delegate handler for HTTP connections
+    ///
+    /// - Returns: a new Server instance
+    static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> ServerType
 
     /// Static method to create a new Server and have it listen for connections.
     ///
@@ -40,6 +59,7 @@ public protocol Server {
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance
+    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' with instead")
     static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType
 
     /// Listen for connections on a socket.

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -26,8 +26,8 @@ public protocol Server {
     /// Port number for listening for new connections.
     var port: Int? { get }
 
-    /// Has the same meaning as in `getaddrinfo()`.
-    var node: String? { get }
+    /// Has the same meaning as node in `getaddrinfo()`.
+    var address: String? { get }
 
     /// A server state.
     var state: ServerState { get }
@@ -35,23 +35,22 @@ public protocol Server {
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
-    /// - Parameter node: has the same meaning as in `getaddrinfo()`
-    func listen(on port: Int, node: String?) throws
+    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    func listen(on port: Int, address: String?) throws
 
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
-    @available(*, deprecated, message: "use 'listen(on:node) throws' with instead")
     func listen(on port: Int) throws
 
     /// Static method to create a new Server and have it listen for connections.
     ///
     /// - Parameter on: port number for accepting new connections
-    /// - Parameter node: has the same meaning as in `getaddrinfo()`
+    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance
-    static func listen(on port: Int, node: String?, delegate: ServerDelegate?) throws -> ServerType
+    static func listen(on port: Int, address: String?, delegate: ServerDelegate?) throws -> ServerType
 
     /// Static method to create a new Server and have it listen for connections.
     ///
@@ -59,7 +58,6 @@ public protocol Server {
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance
-    @available(*, deprecated, message: "use 'listen(on:node:delegate) throws' with instead")
     static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType
 
     /// Listen for connections on a socket.
@@ -113,4 +111,13 @@ public protocol Server {
     /// - Returns: a Server instance
     @discardableResult
     func clientConnectionFailed(callback: @escaping (Swift.Error) -> Void) -> Self
+}
+
+extension Server {
+    public func listen(on port: Int) throws {
+        try listen(on: port, address: nil)
+    }
+    public static func listen(on port: Int, delegate: ServerDelegate?) throws -> ServerType {
+        return try Self.listen(on: port, address: nil, delegate: delegate)
+    }
 }

--- a/Sources/KituraNet/Server/Server.swift
+++ b/Sources/KituraNet/Server/Server.swift
@@ -26,7 +26,8 @@ public protocol Server {
     /// Port number for listening for new connections.
     var port: Int? { get }
 
-    /// Has the same meaning as node in `getaddrinfo()`.
+    /// The address of a network interface to listen on, for example "localhost". The default is nil,
+    /// which listens for connections on all interfaces.
     var address: String? { get }
 
     /// A server state.
@@ -35,7 +36,8 @@ public protocol Server {
     /// Listen for connections on a socket.
     ///
     /// - Parameter on: port number for new connections (eg. 8080)
-    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    /// - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this
+    ///             server will listen on all interfaces.
     func listen(on port: Int, address: String?) throws
 
     /// Listen for connections on a socket.
@@ -46,7 +48,8 @@ public protocol Server {
     /// Static method to create a new Server and have it listen for connections.
     ///
     /// - Parameter on: port number for accepting new connections
-    /// - Parameter address: has the same meaning as node in `getaddrinfo()`
+    /// - Parameter address: The address of the network interface to listen on. Defaults to nil, which means this
+    ///             server will listen on all interfaces.
     /// - Parameter delegate: the delegate handler for HTTP connections
     ///
     /// - Returns: a new Server instance

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -93,7 +93,7 @@ class ClientE2ETests: KituraNetTest {
 
     func testEphemeralListeningPort() {
         do {
-            let server = try HTTPServer.listen(on: 0, node: "localhost", delegate: delegate)
+            let server = try HTTPServer.listen(on: 0, address: "localhost", delegate: delegate)
             _ = HTTP.get("http://localhost:\(server.port!)") { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")

--- a/Tests/KituraNetTests/ClientE2ETests.swift
+++ b/Tests/KituraNetTests/ClientE2ETests.swift
@@ -93,7 +93,7 @@ class ClientE2ETests: KituraNetTest {
 
     func testEphemeralListeningPort() {
         do {
-            let server = try HTTPServer.listen(on: 0, delegate: delegate)
+            let server = try HTTPServer.listen(on: 0, node: "localhost", delegate: delegate)
             _ = HTTP.get("http://localhost:\(server.port!)") { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")

--- a/Tests/KituraNetTests/KituraNIOTest.swift
+++ b/Tests/KituraNetTests/KituraNIOTest.swift
@@ -96,7 +96,7 @@ class KituraNetTest: XCTestCase {
             try server.listen(unixDomainSocketPath: unixDomainSocketPath)
         } else {
             server.allowPortReuse = allowPortReuse
-            try server.listen(on: port, node: "localhost")
+            try server.listen(on: port, address: "localhost")
         }
         return server
     }

--- a/Tests/KituraNetTests/KituraNIOTest.swift
+++ b/Tests/KituraNetTests/KituraNIOTest.swift
@@ -96,7 +96,7 @@ class KituraNetTest: XCTestCase {
             try server.listen(unixDomainSocketPath: unixDomainSocketPath)
         } else {
             server.allowPortReuse = allowPortReuse
-            try server.listen(on: port)
+            try server.listen(on: port, node: "localhost")
         }
         return server
     }

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,7 +55,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: 0)
+            try server.listen(on: 0, node: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -127,7 +127,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: 0)
+            try server.listen(on: 0, node: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -155,7 +155,7 @@ class LifecycleListenerTests: KituraNetTest {
         })
 
         do {
-            try server.listen(on: -1)
+            try server.listen(on: -1, node: nil)
         } catch {
             // Do NOT fail the test if an error is thrown.
             // In this test case an error should be thrown.

--- a/Tests/KituraNetTests/LifecycleListenerTests.swift
+++ b/Tests/KituraNetTests/LifecycleListenerTests.swift
@@ -55,7 +55,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: 0, node: "localhost")
+            try server.listen(on: 0, address: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -127,7 +127,7 @@ class LifecycleListenerTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: 0, node: "localhost")
+            try server.listen(on: 0, address: "localhost")
 
             self.waitForExpectations(timeout: 5) { error in
                 XCTAssertNil(error)
@@ -155,7 +155,7 @@ class LifecycleListenerTests: KituraNetTest {
         })
 
         do {
-            try server.listen(on: -1, node: nil)
+            try server.listen(on: -1, address: nil)
         } catch {
             // Do NOT fail the test if an error is thrown.
             // In this test case an error should be thrown.

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -65,7 +65,7 @@ class MonitoringTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: 0, node: nil)
+            try server.listen(on: 0, address: nil)
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/MonitoringTests.swift
+++ b/Tests/KituraNetTests/MonitoringTests.swift
@@ -65,7 +65,7 @@ class MonitoringTests: KituraNetTest {
         }
 
         do {
-            try server.listen(on: 0)
+            try server.listen(on: 0, node: nil)
             self.waitForExpectations(timeout: 10) { error in
                 server.stop()
                 XCTAssertNil(error)

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -47,7 +47,7 @@ class PipeliningTests: KituraNetTest {
         let server = HTTPServer()
         server.delegate = Delegate()
         do {
-            try server.listen(on: 0, node: "localhost")
+            try server.listen(on: 0, address: "localhost")
         } catch let error {
             Log.error("Server failed to listen. Error: \(error)")
         }
@@ -85,7 +85,7 @@ class PipeliningTests: KituraNetTest {
         server.delegate = Delegate()
         server.delegate = Delegate()
         do {
-            try server.listen(on: 0, node: "localhost")
+            try server.listen(on: 0, address: "localhost")
         } catch let error {
             Log.error("Server failed to listen. Error: \(error)")
         }

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -47,7 +47,7 @@ class PipeliningTests: KituraNetTest {
         let server = HTTPServer()
         server.delegate = Delegate()
         do {
-            try server.listen(on: 0)
+            try server.listen(on: 0, node: "localhost")
         } catch let error {
             Log.error("Server failed to listen. Error: \(error)")
         }
@@ -85,7 +85,7 @@ class PipeliningTests: KituraNetTest {
         server.delegate = Delegate()
         server.delegate = Delegate()
         do {
-            try server.listen(on: 0)
+            try server.listen(on: 0, node: "localhost")
         } catch let error {
             Log.error("Server failed to listen. Error: \(error)")
         }


### PR DESCRIPTION
## Description
@billabt was nice enough to add support for this at the BlueSocket layer [here](https://github.com/IBM-Swift/BlueSocket/commit/9d77d6b2126d099f5e56cace9727068f145daaec). However, I really want to use that functionality to fix https://github.com/IBM-Swift/Kitura/issues/1450.

I also have code ready to go for https://github.com/IBM-Swift/Kitura-net/pull/299 and Kitura.

Obviously, this is the Kitura-NIO version of the Kitura-Net change.

## Motivation and Context
This is necessary to close https://github.com/IBM-Swift/Kitura/issues/1450. Should I open another issue for Kitura-NIO?

## How Has This Been Tested?
Manual testing by myself. I also modified the test harness to use the new code path.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
