### PR TITLE
Send Basic Auth credentials in an Authorization header

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -269,12 +269,12 @@ public class ClientRequest {
         }
         self.path = fullPath
 
-        if let username = url.user {
-            self.userName = username
+        if let username = self.userName, let password = self.password {
+            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
         }
-        if let password = url.password {
-            self.password = password
-        }
+
+        self.url = "\(url.scheme ?? "http")://\(self.hostName ?? "unknown")\(self.port.map { ":\($0)" } ?? "")/\(fullPath)"
+        
     }
 
     /**
@@ -355,17 +355,11 @@ public class ClientRequest {
             }
         }
 
-        // Support for Basic HTTP authentication
-        let user = self.userName ?? ""
-        let pwd = self.password ?? ""
-        var authenticationClause = ""
-        // If either the userName or password are non-empty, add the authenticationClause
-        if !user.isEmpty || !pwd.isEmpty {
-          authenticationClause = "\(user):\(pwd)@"
+        if let username = self.userName, let password = self.password {
+            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
         }
-
         //the url string
-        self.url = "\(theSchema)\(authenticationClause)\(hostName)\(port)\(path)"
+        self.url = "\(theSchema)\(hostName)\(port)\(path)"
         self.percentEncodedURL = percentEncode(self.url)
     }
 
@@ -557,10 +551,6 @@ public class ClientRequest {
 
         if closeConnection {
             self.headers["Connection"] = "close"
-        }
-
-        if let username = self.userName, let password = self.password {
-            self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
         }
 
         if self.port == nil {

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -269,6 +269,14 @@ public class ClientRequest {
         }
         self.path = fullPath
 
+        if let username = url.user {
+             self.userName = username
+        }
+
+        if let password = url.password {
+            self.password = password
+        }
+
         if let username = self.userName, let password = self.password {
             self.headers["Authorization"] = createHTTPBasicAuthHeader(username: username, password: password)
         }

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -270,7 +270,7 @@ public class ClientRequest {
         self.path = fullPath
 
         if let username = url.user {
-             self.userName = username
+            self.userName = username
         }
 
         if let password = url.password {

--- a/Tests/KituraNetTests/ClientRequestTests.swift
+++ b/Tests/KituraNetTests/ClientRequestTests.swift
@@ -97,7 +97,7 @@ class ClientRequestTests: KituraNetTest {
         testRequest.set(.headers(["X-Custom": "Swift"]))
         testRequest.set(.maxRedirects(3))
         testRequest.set(.disableSSLVerification)
-        XCTAssertEqual(testRequest.url, "https://66o.tech:8080")
+        XCTAssertEqual(testRequest.url, "https://66o.tech:8080/")
     }
 
     func testClientRequestParse() {

--- a/Tests/KituraNetTests/ClientRequestTests.swift
+++ b/Tests/KituraNetTests/ClientRequestTests.swift
@@ -23,6 +23,12 @@ class ClientRequestTests: KituraNetTest {
     let testCallback: ClientRequest.Callback = {_ in }
     // 1 test URL that is build when initializing with ClientRequestOptions
 
+    private func httpBasicAuthHeader(username: String, password: String) -> String {
+        let authHeader = "\(username):\(password)"
+        let data = Data(authHeader.utf8)
+        return "Basic \(data.base64EncodedString())"
+    }
+
     func testClientRequestWhenInitializedWithValidURL() {
         let options: [ClientRequest.Options] = [ .method("GET"),
                                                  .schema("https://"),
@@ -97,8 +103,9 @@ class ClientRequestTests: KituraNetTest {
     func testClientRequestParse() {
         let options = ClientRequest.parse("https://username:password@66o.tech:8080/path?key=value")
         let testRequest = ClientRequest(options: options, callback: testCallback)
-        XCTAssertEqual(testRequest.url, "https://username:password@66o.tech:8080/path?key=value")
-
+        XCTAssertEqual(testRequest.url, "https://66o.tech:8080/path?key=value")
+        let authHeaderValue = testRequest.headers["Authorization"] ?? ""
+        XCTAssertEqual(authHeaderValue, httpBasicAuthHeader(username: "username", password: "password"))
         let options1: [ClientRequest.Options] = [ .schema("https"),
                                                   .hostname("66o.tech"),
                                                   .path("/view/matching?key=\"viewTest\"")
@@ -121,14 +128,18 @@ class ClientRequestTests: KituraNetTest {
                                              .hostname("66o.tech")
         ]
         var testRequest = ClientRequest(options: options, callback: testCallback)
-        XCTAssertEqual(testRequest.url, "http://myusername:@66o.tech")
+        XCTAssertNil(testRequest.headers["Authorization"])
+        XCTAssertEqual(testRequest.userName, "myusername")
+        XCTAssertEqual(testRequest.url, "http://66o.tech")
 
         // ensure an empty username works
         let options2: [ClientRequest.Options] = [ .password("mypassword"),
                                                   .hostname("66o.tech")
         ]
         testRequest = ClientRequest(options: options2, callback: testCallback)
-        XCTAssertEqual(testRequest.url, "http://:mypassword@66o.tech")
+        XCTAssertNil(testRequest.headers["Authorization"])
+        XCTAssertEqual(testRequest.password, "mypassword")
+        XCTAssertEqual(testRequest.url, "http://66o.tech")
 
         // ensure username:password works
         let options3: [ClientRequest.Options] = [ .username("myusername"),
@@ -136,7 +147,9 @@ class ClientRequestTests: KituraNetTest {
                                                   .hostname("66o.tech")
         ]
         testRequest = ClientRequest(options: options3, callback: testCallback)
-        XCTAssertEqual(testRequest.url, "http://myusername:mypassword@66o.tech")
+        let authHeaderValue = testRequest.headers["Authorization"] ?? ""
+        XCTAssertEqual(authHeaderValue, httpBasicAuthHeader(username: "myusername", password: "mypassword"))
+        XCTAssertEqual(testRequest.url, "http://66o.tech")
     }
 
     func testClientRequestSyncBehavior() {


### PR DESCRIPTION
The username and password are currently sent as a part of the url. This can be a challenge
if the url need to be percent encoded. The username and password also need to be percent
encoded then. It is easier to send username and password in the Authorization header. Note that
this will change the behaviour of `ClientRequent.url`.

This is for #178 . **It is a breaking change.**