### PR TITLE
Remove setting of the TCP_NODELAY option, its now default

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.1.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.3.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3")

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -301,7 +301,7 @@ public class HTTPServer: Server {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), value: allowPortReuse ? 1 : 0)
             .childChannelInitializer { channel in
                 let httpHandler = HTTPRequestHandler(for: self)
-                let config: HTTPUpgradeConfiguration = (upgraders: upgraders, completionHandler: { ctx in
+                let config: NIOHTTPServerUpgradeConfiguration = (upgraders: upgraders, completionHandler: { ctx in
                     self.ctx = ctx
                     _ = channel.pipeline.removeHandler(httpHandler)
                 })

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -312,7 +312,6 @@ public class HTTPServer: Server {
                     return channel.pipeline.addHandler(httpHandler)
                 }
             }
-            .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
 
         let listenerDescription: String
         do {

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -61,7 +61,6 @@ class PipeliningTests: KituraNetTest {
                     channel.pipeline.addHandler(PipelinedRequestsHandler(with: expectation))
                 }
             }
-            .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .connect(host: "localhost", port: server.port!).wait()
             let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/")
             for _ in 0...4 {
@@ -99,7 +98,6 @@ class PipeliningTests: KituraNetTest {
                         channel.pipeline.addHandler(PipelinedRequestsHandler(with: expectation))
                     }
                 }
-                .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
                 .connect(host: "localhost", port: server.port!).wait()
             let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .POST, uri: "/")
             for _ in 0...5 {


### PR DESCRIPTION
Setting TCP_NODELAY option that disables Nagles algorithm, thereby improving
throughput, has been made the default in NIO 2.3.1. We shouldn't repeat this in
Kitura-NIO. See https://github.com/apple/swift-nio/pull/1020 for details.