### PR TITLE
Add default Accept header and port number to Host

### DIFF
--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -557,7 +557,7 @@ public class ClientRequest {
 
         // To keep Kitura-NIO's behaviour similar to Kitura-net, add the Accept header with default value '*/*'.
         // Note:libcurl adds default value for Accept header for Kitura-net
-        if self.headers["Accept"] == nil {
+        if self.headers["Accept"] == nil && self.headers["accept"] == nil {
            self.headers["Accept"] = "*/*"
         }
 

--- a/Sources/KituraNet/ClientRequest.swift
+++ b/Sources/KituraNet/ClientRequest.swift
@@ -549,8 +549,16 @@ public class ClientRequest {
         }
 
         let hostName = URL(string: percentEncodedURL)?.host ?? "" //TODO: what could be the failure path here
+        let portNumber = URL(string: percentEncodedURL)?.port ?? 8080
         if self.headers["Host"] == nil {
-           self.headers["Host"] = hostName
+           let isNotDefaultPort = (portNumber != 443 && portNumber != 80) //Check whether port is not 443/80
+           self.headers["Host"] = hostName + (isNotDefaultPort ? (":" + String(portNumber)) : "")
+        }
+
+        // To keep Kitura-NIO's behaviour similar to Kitura-net, add the Accept header with default value '*/*'.
+        // Note:libcurl adds default value for Accept header for Kitura-net
+        if self.headers["Accept"] == nil {
+           self.headers["Accept"] = "*/*"
         }
 
         self.headers["User-Agent"] = "Kitura"


### PR DESCRIPTION
Kitura-net adds a default Accept header and appends port number to host name if
non-default ports(443/80) are used. In order to maintain parity default Accept
header is added and port name is appended if non default port is used.