### PR TITLE
Fix to set property ClientResponse.status right

### DIFF
--- a/Sources/KituraNet/ClientResponse.swift
+++ b/Sources/KituraNet/ClientResponse.swift
@@ -53,16 +53,13 @@ public class ClientResponse {
         }
     }
     /// The HTTP Status code, as an Int, sent in the response by the remote server.
-    public internal(set) var status = -1 {
-        didSet {
-            statusCode = HTTPStatusCode(rawValue: status) ?? .unknown
-        }
-    }
+    public internal(set) var status = -1
 
     /// The HTTP Status code, as an `HTTPStatusCode`, sent in the response by the remote server.
     public internal(set) var statusCode: HTTPStatusCode = HTTPStatusCode.unknown {
         didSet {
             httpStatusCode = statusCode
+            status = statusCode.rawValue
         }
     }
 


### PR DESCRIPTION
Kitura-NIO wrongly returned -1 as status code.The property
ClientResponse.status now updates when ClientResponse.statusCode is
updated.Observer didSet is removed from ClientResponse.status as observers of
both status and statusCode trigger each other and cause stackoverflow.The
changes made ensure the property ClientResonse.status is set right.