### PR TITLE
Allow HTTPServerRequest creation on the current EventLoop only

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -294,9 +294,4 @@ extension EventLoop {
             }
         }
     }
-
-    func runAndWait(_ task: @escaping () -> Void) throws {
-        guard let eventLoopFuture = run(task) else { return }
-        try eventLoopFuture.wait()
-    }
 }


### PR DESCRIPTION
An `HTTPServerRequest` abstracts a received HTTP request. Though an
`HTTPServerRequest` must be strictly associated with an HTTP connection,
Kitura-NIO allowed creation of HTTPServerRequests from anywhere. Consequently,
to build the `URL` for the `urlURL` property, when we need to access
`ChannelHandlerContext` properties like `localAddress` or `remoteAddress`, that
code needs to be dispatched to the EventLoop. Because the computation of
`urlURL` is synchronous, we also need to wait() for the EventLoop to return. If
`urlURL` were invoked on an EventLoop, like we do in `Kitura-WebSocket-NIO`, we
fail with a SwiftNIO assertion that doesn't permit wait() to be invoked on an
`EventLoop`.

The best possible solution to this issue is to restrict the HTTPServerRequest
creation on the EventLoop associated with the underlying HTTP connection only.
The `ChannelHandlerContext` properties could then be accessed in the 
initializer.