### PR TITLE
Remove a race condition from the WebSocket upgrade

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -79,7 +79,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
 
         switch request {
         case .head(let header):
-            serverRequest = HTTPServerRequest(ctx: context, requestHead: header, enableSSL: enableSSLVerification)
+            serverRequest = HTTPServerRequest(channel: context.channel, requestHead: header, enableSSL: enableSSLVerification)
             self.clientRequestedKeepAlive = header.isKeepAlive
         case .body(var buffer):
             guard let serverRequest = serverRequest else {

--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -180,7 +180,7 @@ public class HTTPServerRequest: ServerRequest {
     */
     public var method: String
 
-    private let ctx: ChannelHandlerContext
+    private let channel: Channel
 
     private var enableSSL: Bool = false
 
@@ -208,20 +208,20 @@ public class HTTPServerRequest: ServerRequest {
         }
     }
 
-    init(ctx: ChannelHandlerContext, requestHead: HTTPRequestHead, enableSSL: Bool) {
+    init(channel: Channel, requestHead: HTTPRequestHead, enableSSL: Bool) {
         // An HTTPServerRequest may be created only on the EventLoop assigned to handle
         // the connection on which the HTTP request arrived.
-        assert(ctx.eventLoop.inEventLoop)
-        self.ctx = ctx
+        assert(channel.eventLoop.inEventLoop)
+        self.channel = channel
         self.headers = HeadersContainer(with: requestHead.headers)
         self.method = requestHead.method.rawValue
         self.httpVersionMajor = UInt16(requestHead.version.major)
         self.httpVersionMinor = UInt16(requestHead.version.minor)
         self.rawURLString = requestHead.uri
         self.enableSSL = enableSSL
-        self.localAddressHost = HTTPServerRequest.host(socketAddress: ctx.localAddress)
-        self.localAddressPort = ctx.localAddress?.port ?? 0
-        self.remoteAddress = HTTPServerRequest.host(socketAddress: ctx.remoteAddress)
+        self.localAddressHost = HTTPServerRequest.host(socketAddress: channel.localAddress)
+        self.localAddressPort = channel.localAddress?.port ?? 0
+        self.remoteAddress = HTTPServerRequest.host(socketAddress: channel.remoteAddress)
     }
 
     var buffer: BufferList?


### PR DESCRIPTION
An upgrade to WebSocket invokes three handlers in an order. First, the
`shouldUpgrade` handler supplied by the user is run to decide if an upgrade
must go through. This handler also supplies additional headers to be sent in
the response. Next, after the WebSocket upgrader is done upgrading the
pipeline, the `completionHandler` is called. We remove Kitura-NIO's
`HTTPRequestHandler` here. Next, the `upgradePipelineHandler` is invoked. This
handler allows us to add all the WebSocket related `ChannelHandler`s.

For an undocumented reason, we saved the `ChannelHandlerContext` received by
the `completionHandler` in the `HTTPServer` and later used it upgrade the
pipeline in `upgradePipelineHandler`. This can easily lead to a race condition
where we saved the `ChannelHandlerContext` for a connection, into the
`HTTPServer` but before it could be used in `upgradePipelineHandler`, it was
overwritten by the upgrade happening on another connection. Consequently, we
never upgraded the pipeline of the former connection. This could lead to
different kinds of failures.

The `upgradePipelineHandler` has `Channel` as one of its parameters. Hence
there is no need to store the `ChannelHandlerContext` for use in this closure.
Consequently, we have to use a `Channel` to initialize an `HTTPServerRequest`,
which, in turn, is modified to accept a `Channel` instead of a
`ChannelHandlerContext`.