### PR TITLE
 [WIP] feat: Ability to limit request size and connection count using HTTPServerConfigurationHandler.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3")
+        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -42,7 +42,7 @@ let package = Package(
             dependencies: []),
         .target(
             name: "KituraNet",
-            dependencies: ["NIO", "NIOFoundationCompat", "NIOHTTP1", "NIOSSL", "SSLService", "LoggerAPI", "NIOWebSocket", "CLinuxHelpers", "NIOExtras"]),
+            dependencies: ["NIO", "NIOFoundationCompat", "NIOHTTP1", "NIOSSL", "SSLService", "LoggerAPI", "NIOWebSocket", "CLinuxHelpers", "NIOExtras", "NIOConcurrencyHelpers"]),
         .testTarget(
             name: "KituraNetTests",
             dependencies: ["KituraNet"])

--- a/Sources/KituraNet/HTTP/HTTP.swift
+++ b/Sources/KituraNet/HTTP/HTTP.swift
@@ -87,8 +87,9 @@ public class HTTP {
     let server = HTTP.createServer()
     ````
     */
-    public static func createServer() -> HTTPServer {
-        return HTTPServer()
+    public static func createServer(serverConfig: HTTPServerConfiguration = .default) -> HTTPServer {
+        let serverConfig = serverConfig
+        return HTTPServer(serverConfig: serverConfig)
     }
 
     /**

--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -99,6 +99,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
                 serverRequest.buffer!.byteBuffer.writeBuffer(&buffer)
             }
         case .end:
+            let resetRequestSize = 0
             serverResponse = HTTPServerResponse(channel: context.channel, handler: self)
             //Make sure we use the latest delegate registered with the server
             DispatchQueue.global().async {
@@ -107,14 +108,12 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
                 Monitor.delegate?.started(request: serverRequest, response: serverResponse)
                 delegate.handle(request: serverRequest, response: serverResponse)
             }
+            self.userInboundEventTriggered(context: context, event: resetRequestSize)
         }
     }
 
-    //IdleStateEvents are received on this method
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        if event is IdleStateHandler.IdleStateEvent {
-            _ = context.close()
-        }
+        context.triggerUserOutboundEvent(event, promise: nil)
     }
 
     public func channelReadComplete(context: ChannelHandlerContext) {

--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -82,7 +82,8 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
                 let contentLength = header.headers["Content-Length"].first,
                     let contentLengthValue = Int(contentLength) {
                     if contentLengthValue > requestSizeLimit {
-                        sendStatus(context: context)
+                        sendRequestTooLongResponse(context: context)
+                        context.close()
                     }
             }
             serverRequest = HTTPServerRequest(channel: context.channel, requestHead: header, enableSSL: enableSSLVerification)
@@ -159,7 +160,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
         keepAliveState.decrement()
     }
 
-    func sendStatus(context: ChannelHandlerContext) {
+    func sendRequestTooLongResponse(context: ChannelHandlerContext) {
         let statusDescription = HTTP.statusCodes[HTTPStatusCode.requestTooLong.rawValue] ?? ""
         do {
             serverResponse = HTTPServerResponse(channel: context.channel, handler: self)

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -324,11 +324,11 @@ public class HTTPServer: Server {
                 })
                 return channel.pipeline.configureHTTPServerPipeline(withServerUpgrade: config, withErrorHandling: true).flatMap {
                     if let nioSSLServerHandler = self.createNIOSSLServerHandler() {
-                        _ = channel.pipeline.addHandler(nioSSLServerHandler, position: .first)
+                        return channel.pipeline.addHandler(nioSSLServerHandler, position: .first)
                     }
-                    _ = channel.pipeline.addHandler(serverConfigurationHandler, position: .first)
-                    return channel.pipeline.addHandler(httpHandler)
-                }
+                    return channel.eventLoop.makeSucceededFuture(()) } .flatMap {
+                        return channel.pipeline.addHandler(serverConfigurationHandler, position: .first) }.flatMap {
+                            return channel.pipeline.addHandler(httpHandler)}
             }
 
         let listenerDescription: String

--- a/Sources/KituraNet/HTTP/HTTPServerConfiguration.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerConfiguration.swift
@@ -1,0 +1,47 @@
+/*
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public struct HTTPServerConfiguration {
+    /// Defines the maximum size of an incoming request, in bytes. If requests are received that are larger
+    /// than this limit, they will be rejected and the connection will be closed.
+
+    /// A value of `nil` means no limit.
+    public let requestSizeLimit: Int?
+    
+    /// Defines the maximum number of concurrent connections that a server should accept. Clients attempting
+    /// to connect when this limit has been reached will be rejected.
+    /// A value of `nil` means no limit.
+    public let connectionLimit: Int?
+
+    /// A default limit of 1mb on the size of requests that a server should accept
+    /// A default limit of 10,000 on the number of concurrent connections that a server should accept.
+    public static var `default` = HTTPServerConfiguration(requestSizeLimit: 1048576, connectionLimit: 10000)
+    
+    
+    /// Create an `HTTPServerConfiguration` to determine the behaviour of a `Server`.
+    ///
+    /// - parameter requestSizeLimit: The maximum size of an incoming request. Defaults to `IncomingSocketOptions.defaultRequestSizeLimit`.
+    /// - parameter connectionLimit: The maximum number of concurrent connections. Defaults to `IncomingSocketOptions.defaultConnectionLimit`.
+    
+    public init(requestSizeLimit: Int?, connectionLimit: Int?)
+    {
+        self.requestSizeLimit = requestSizeLimit
+        self.connectionLimit = connectionLimit
+    }
+    
+}

--- a/Sources/KituraNet/HTTP/HTTPServerConfigurationHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerConfigurationHandler.swift
@@ -46,11 +46,9 @@ internal class HTTPServerConfigurationHandler: ChannelDuplexHandler {
         context.fireChannelRead(wrapInboundOut(data))
     }
     
-    public func channelReadComplete(context: ChannelHandlerContext){
-        requestSize = 0
-        context.fireChannelReadComplete()
+    public func triggerUserOutboundEvent(context: ChannelHandlerContext, event: Any, promise: EventLoopPromise<Void>?) {
+        requestSize = event as? Int ?? 0
     }
-    
     public func channelActive(context: ChannelHandlerContext) {
         _ = server.connectionCount.add(1)
         if let connectionLimit1 = connectionLimit {

--- a/Sources/KituraNet/HTTP/HTTPServerConfigurationHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerConfigurationHandler.swift
@@ -1,0 +1,76 @@
+import NIO
+import NIOHTTP1
+import NIOWebSocket
+import LoggerAPI
+import Foundation
+import Dispatch
+import NIOConcurrencyHelpers
+
+internal class HTTPServerConfigurationHandler: ChannelDuplexHandler {
+    // The HTTPServer instance on which this handler is installed
+    var server: HTTPServer
+    let requestSizeLimit: Int?
+    let connectionLimit: Int?
+    var requestSize: Int = 0
+    var connectionCount = 0
+    typealias InboundIn = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+    
+    public init(for server: HTTPServer) {
+        self.server = server
+//        if let requestSizeLimit = server.serverConfig.requestSizeLimit {
+//            self.requestSizeLimit = requestSizeLimit
+//        }
+//        if let connectionLimit = server.serverConfig.connectionLimit {
+//            self.connectionLimit = connectionLimit
+//        }
+        self.requestSizeLimit = server.serverConfig.requestSizeLimit ?? nil
+        self.connectionLimit = server.serverConfig.connectionLimit ?? nil
+    }
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let data = self.unwrapInboundIn(data)
+        requestSize = requestSize + data.readableBytes
+        if let requestSizeLimit1 = requestSizeLimit {
+            if requestSize > requestSizeLimit1 {
+                let statusDescription = HTTP.statusCodes[HTTPStatusCode.requestTooLong.rawValue] ?? ""
+                var discriptionBuffer = ByteBufferAllocator().buffer(capacity: requestSizeLimit!)
+                discriptionBuffer.writeString(statusDescription)
+                context.writeAndFlush(NIOAny(discriptionBuffer),promise: nil)
+                requestSize = 0
+                context.close(mode: .all, promise: nil)
+                return
+            }
+        }
+        context.fireChannelRead(wrapInboundOut(data))
+    }
+    
+    public func channelReadComplete(context: ChannelHandlerContext){
+        requestSize = 0
+        context.fireChannelReadComplete()
+    }
+    
+    public func channelActive(context: ChannelHandlerContext) {
+        _ = server.connectionCount.add(1)
+        if let connectionLimit1 = connectionLimit {
+            if server.connectionCount.load() > connectionLimit1{
+                let statusDescription = HTTP.statusCodes[HTTPStatusCode.serviceUnavailable.rawValue] ?? ""
+                var statusBuffer = ByteBufferAllocator().buffer(capacity: 1024)
+                statusBuffer.writeString(statusDescription)
+                context.writeAndFlush(NIOAny(statusBuffer),promise: nil)
+                _ = server.connectionCount.sub(1)
+                context.close(mode: .all, promise: nil)
+                return
+            }
+        }
+        context.fireChannelActive()
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        _ = server.connectionCount.sub(1)
+        context.fireChannelInactive()
+    }
+}
+
+

--- a/Tests/KituraNetTests/HTTPResponseHandler.swift
+++ b/Tests/KituraNetTests/HTTPResponseHandler.swift
@@ -1,0 +1,24 @@
+import NIO
+import NIOHTTP1
+import NIOWebSocket
+import LoggerAPI
+import Foundation
+import Dispatch
+import XCTest
+@testable import KituraNet
+internal class HTTPConfigTestsResponseHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+    let expectedSubstring: String
+    let expectation: XCTestExpectation
+    public init(expectation: XCTestExpectation, expectedSubstring: String ){
+        self.expectedSubstring = expectedSubstring
+        self.expectation = expectation
+    }
+    
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let response = self.unwrapInboundIn(data)
+        XCTAssert(response.getString(at: 0, length: response.readableBytes)?.starts(with: expectedSubstring) ?? false)
+        expectation.fulfill()
+    }
+}
+

--- a/Tests/KituraNetTests/HTTPResponseTests.swift
+++ b/Tests/KituraNetTests/HTTPResponseTests.swift
@@ -40,7 +40,7 @@ class HTTPResponseTests: KituraNetTest {
         let headers = HeadersContainer()
 
         headers.append("Content-Type", value: "text/html")
-        var values = headers["Content-Type"]
+        let values = headers["Content-Type"]
         XCTAssertNotNil(values, "Couldn't retrieve just set Content-Type header")
         XCTAssertEqual(values?.count, 1, "Content-Type header should only have one value")
         XCTAssertEqual(values?[0], "text/html")

--- a/Tests/KituraNetTests/KituraNIOTest.swift
+++ b/Tests/KituraNetTests/KituraNIOTest.swift
@@ -85,9 +85,9 @@ class KituraNetTest: XCTestCase {
         }
     }
 
-    func startServer(_ delegate: ServerDelegate?, unixDomainSocketPath: String? = nil, port: Int = portDefault, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault) throws -> HTTPServer {
-
-        let server = HTTP.createServer()
+    func startServer(_ delegate: ServerDelegate?, unixDomainSocketPath: String? = nil, port: Int = portDefault, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, serverConfig: HTTPServerConfiguration = .default) throws -> HTTPServer {
+        let serverConfig = serverConfig
+        let server = HTTP.createServer(serverConfig: serverConfig)
         server.delegate = delegate
         if useSSL {
             server.sslConfig = KituraNetTest.sslConfig
@@ -103,8 +103,9 @@ class KituraNetTest: XCTestCase {
 
     /// Convenience function for starting an HTTPServer on an ephemeral port,
     /// returning the a tuple containing the server and the port it is listening on.
-    func startEphemeralServer(_ delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault) throws -> (server: HTTPServer, port: Int) {
-        let server = try startServer(delegate, port: 0, useSSL: useSSL, allowPortReuse: allowPortReuse)
+    func startEphemeralServer(_ delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, serverConfig: HTTPServerConfiguration = .default) throws -> (server: HTTPServer, port: Int) {
+        let serverConfig = serverConfig
+        let server = try startServer(delegate, port: 0, useSSL: useSSL, allowPortReuse: allowPortReuse, serverConfig: serverConfig)
         guard let serverPort = server.port else {
             throw KituraNetTestError(message: "Server port was not initialized")
         }
@@ -121,26 +122,26 @@ class KituraNetTest: XCTestCase {
         case both
     }
 
-    func performServerTest(_ delegate: ServerDelegate?, socketType: SocketType = .both, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
+    func performServerTest(serverConfig: HTTPServerConfiguration = .default, _ delegate: ServerDelegate?, socketType: SocketType = .both, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
+        let serverConfig = serverConfig
         self.socketType = socketType
         if socketType != .tcp {
-            performServerTestWithUnixSocket(delegate: delegate, useSSL: useSSL, allowPortReuse: allowPortReuse, line: line, asyncTasks: asyncTasks)
+            performServerTestWithUnixSocket(serverConfig: serverConfig, delegate: delegate, useSSL: useSSL, allowPortReuse: allowPortReuse, line: line, asyncTasks: asyncTasks)
         }
         if socketType != .unixDomainSocket {
-            performServerTestWithTCPPort(delegate: delegate, useSSL: useSSL, allowPortReuse:  allowPortReuse, line: line, asyncTasks: asyncTasks)
+            performServerTestWithTCPPort(serverConfig: serverConfig, delegate: delegate, useSSL: useSSL, allowPortReuse:  allowPortReuse, line: line, asyncTasks: asyncTasks)
         }
     }
 
-    func performServerTestWithUnixSocket(delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, line: Int = #line, asyncTasks: [(XCTestExpectation) -> Void]) { 
+    func performServerTestWithUnixSocket(serverConfig: HTTPServerConfiguration = .default, delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, line: Int = #line, asyncTasks: [(XCTestExpectation) -> Void]) {
         do {
             var server: HTTPServer
             self.useSSL = useSSL
             self.unixDomainSocketPath = self.socketFilePath
-            server = try startServer(delegate, unixDomainSocketPath: self.unixDomainSocketPath, useSSL: useSSL, allowPortReuse: allowPortReuse)
+            server = try startServer(delegate, unixDomainSocketPath: self.unixDomainSocketPath, useSSL: useSSL, allowPortReuse: allowPortReuse, serverConfig: serverConfig)
             defer {
                 server.stop()
             }
-
             let requestQueue = DispatchQueue(label: "Request queue")
             for (index, asyncTask) in asyncTasks.enumerated() {
                 let expectation = self.expectation(line: line, index: index)
@@ -158,18 +159,17 @@ class KituraNetTest: XCTestCase {
         }
     }
 
-    func performServerTestWithTCPPort(delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, line: Int = #line, asyncTasks: [(XCTestExpectation) -> Void]) { 
+    func performServerTestWithTCPPort(serverConfig: HTTPServerConfiguration = .default, delegate: ServerDelegate?, useSSL: Bool = useSSLDefault, allowPortReuse: Bool = portReuseDefault, line: Int = #line, asyncTasks: [(XCTestExpectation) -> Void]) {
         do {
             var server: HTTPServer
             var ephemeralPort: Int = 0
             self.useSSL = useSSL
-            (server, ephemeralPort) = try startEphemeralServer(delegate, useSSL: useSSL, allowPortReuse: allowPortReuse)
+            (server, ephemeralPort) = try startEphemeralServer(delegate, useSSL: useSSL, allowPortReuse: allowPortReuse, serverConfig: serverConfig)
             self.port = ephemeralPort
             self.unixDomainSocketPath = nil
             defer {
                 server.stop()
             }
-
             let requestQueue = DispatchQueue(label: "Request queue")
             for (index, asyncTask) in asyncTasks.enumerated() {
                 let expectation = self.expectation(line: line, index: index)

--- a/Tests/KituraNetTests/LargePayloadTests.swift
+++ b/Tests/KituraNetTests/LargePayloadTests.swift
@@ -40,7 +40,7 @@ class LargePayloadTests: KituraNetTest {
     private let delegate = TestServerDelegate()
 
     func testLargePosts() {
-        performServerTest(delegate, useSSL: false, asyncTasks: { expectation in
+        performServerTest(serverConfig: HTTPServerConfiguration(requestSizeLimit: 100*10000, connectionLimit: 1),delegate,socketType: .tcp, useSSL: false, asyncTasks: { expectation in
             let payload = "[" + contentTypesString + "," + contentTypesString + contentTypesString + "," + contentTypesString + "]"
             self.performRequest("post", path: "/largepost", callback: {response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Status code wasn't .Ok was \(String(describing: response?.statusCode))")

--- a/Tests/KituraNetTests/PipeliningTests.swift
+++ b/Tests/KituraNetTests/PipeliningTests.swift
@@ -80,7 +80,7 @@ class PipeliningTests: KituraNetTest {
     /// spanning several packets. It is necessary to sleep between writes to allow
     /// the server time to receive and process the data.
     func testPipeliningSpanningPackets() {
-        let server = HTTPServer()
+        let server = HTTPServer(serverConfig: HTTPServerConfiguration(requestSizeLimit: 100*1024, connectionLimit: 1))
         server.delegate = Delegate()
         server.delegate = Delegate()
         do {

--- a/Tests/KituraNetTests/RequestSizeTests.swift
+++ b/Tests/KituraNetTests/RequestSizeTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Dispatch
+import NIO
+import XCTest
+import KituraNet
+import NIOHTTP1
+import NIOWebSocket
+import LoggerAPI
+
+class RequestSizeTests: KituraNetTest {
+    static var allTests: [(String, (RequestSizeTests) -> () throws -> Void)] {
+        return [
+            ("testRequestSize", testRequestSize),
+            ("testConnectionLimit",testConnectionLimit),
+        ]
+    }
+    
+    override func setUp() {
+        doSetUp()
+    }
+    
+    override func tearDown() {
+        doTearDown()
+    }
+    private func sendRequest(request:HTTPRequestHead, on channel: Channel, payload: ByteBuffer) {
+        channel.write(NIOAny(HTTPClientRequestPart.head(request)), promise: nil)
+        channel.write(NIOAny(HTTPClientRequestPart.body(.byteBuffer(payload))), promise: nil)
+        channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
+    }
+
+    func establishConnection(expectation: XCTestExpectation, responseHandler: HTTPConfigTestsResponseHandler, payload: ByteBuffer) -> Channel {
+        var channel: Channel? = nil
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let bootstrap = ClientBootstrap(group: group)
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .channelInitializer { channel in
+                 return channel.pipeline.addHTTPClientHandlers().flatMap {_ in
+                    channel.pipeline.addHandler(responseHandler, position: .first)
+                }
+        }
+        do {
+            try channel = bootstrap.connect(host: "localhost", port: self.port).wait()
+            let request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .POST, uri: "/")
+            self.sendRequest(request: request, on: channel!, payload: payload )
+        } catch {
+            XCTFail("Connection is not established.")
+        }
+        return channel!
+    }
+    
+    func testRequestSize () {
+        performServerTest(serverConfig: HTTPServerConfiguration(requestSizeLimit: 10000, connectionLimit: 1), nil, socketType: .tcp, useSSL: false, asyncTasks: { expectation in
+            let payload = "[" + contentTypesString + "]"
+            var payloadBuffer = ByteBufferAllocator().buffer(capacity: 10000)
+            payloadBuffer.writeString(payload)
+            _ = self.establishConnection(expectation: expectation, responseHandler: HTTPConfigTestsResponseHandler(expectation: expectation, expectedSubstring:HTTP.statusCodes[HTTPStatusCode.requestTooLong.rawValue] ?? ""), payload: payloadBuffer)
+        })
+    }
+    func testConnectionLimit() {
+        let delegate = TestConnectionLimitDelegate()
+        performServerTest(serverConfig: HTTPServerConfiguration(requestSizeLimit: 10000, connectionLimit: 1), delegate, socketType: .tcp, useSSL: false, asyncTasks: { expectation in
+            let payload = "Hello, World!"
+            var payloadBuffer = ByteBufferAllocator().buffer(capacity: 1024)
+            payloadBuffer.writeString(payload)
+             _ = self.establishConnection(expectation: expectation, responseHandler: HTTPConfigTestsResponseHandler(expectation: expectation, expectedSubstring:"HTTP/1.1 200 OK"), payload: payloadBuffer)
+        }, { expectation in
+            let payload = "Hello, World!"
+            var payloadBuffer = ByteBufferAllocator().buffer(capacity: 1024)
+            payloadBuffer.writeString(payload)
+             _ =  self.establishConnection(expectation: expectation, responseHandler: HTTPConfigTestsResponseHandler(expectation: expectation, expectedSubstring: HTTP.statusCodes[HTTPStatusCode.serviceUnavailable.rawValue] ?? ""), payload: payloadBuffer)
+        })
+    }
+}
+class TestConnectionLimitDelegate: ServerDelegate {
+    func handle(request: ServerRequest, response: ServerResponse) {
+        do {
+            try response.end()
+        } catch {
+            XCTFail("Error while writing response")
+        }
+    }
+}


### PR DESCRIPTION
### **Description**

This PR allows a requestSizeLimit (maximum bytes for a request, including the header size) and connectionLimit (total number of concurrent connections) to be configured when registering a server. Here a new duplex handler `HTTPServerConfigurationHandler` is used to check request size and connection count. This handler is placed before NIOSSL handler.

Example usage:
`let serverConfig = HTTPServerConfiguration(requestSizeLimit: 10000, connectionLimit: 100)`

If you do not specify either of the parameters, or do not specify aHTTPServerConfiguration at all, then default values are used. The defaults are defined in `HTTPServerConfiguration` in Kitura-NIO here: https://github.com/RudraniW/Kitura-NIO/blob/limitRequestSize/Sources/KituraNet/HTTP/HTTPServerConfiguration.swift

### **Motivation and Context**
see: #206 