### PR TITLE
Add api to access eventloopGroup in Kitura-NIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["KituraNet"])
     ],
     dependencies: [
-        // FIXME: remove version constraint once IBM-Swift/Kitura-NIO#225 is merged
-        .package(url: "https://github.com/apple/swift-nio.git", "2.3.0"..."2.8.0"),
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/BlueSSLService.git", from: "1.0.0"),

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -137,6 +137,11 @@ public class HTTPServer: Server {
 
     /// The EventLoopGroup used by this HTTPServer. This property may be assigned
     /// once and once only, by calling `setEventLoopGroup(value:)` before `listen()` is called.
+    /// Server runs on `eventLoopGroup` which it is initialized to i.e. when user explicitly provides `eventLoopGroup` for server,
+    /// public variable `eventLoopGroup` will  return value stored private variable `_eventLoopGroup` when `ServerBootstrap` is called in `listen()`
+    /// making the server run of userdefined EventLoopGroup. If the `setEventLoopGroup(value:)` is not called, `nil` in variable `_eventLoopGroup` forces
+    /// Server to run in `globalELG` since value of `eventLoopGroup` in `ServerBootstrap(group: eventLoopGroup)` gets initialzed to value `globalELG`
+    /// if `setEventLoopGroup(value:)` is not called before `listen()`
     public var eventLoopGroup: EventLoopGroup {
         if let value = self._eventLoopGroup { return value }
         let value = globalELG

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -715,8 +715,8 @@ enum KituraWebSocketUpgradeError: Error {
     case unknownUpgradeError
 }
 
-// HTTP server errors
-public struct HTTPServerError: Error,Equatable {
+/// Errors thrown by HTTPServer
+public struct HTTPServerError: Error, Equatable {
 
     internal enum HTTPServerErrorType: Error {
         case eventLoopGroupAlreadyInitialized

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -141,6 +141,10 @@ public class HTTPServer: Server {
     /// making the server run of userdefined EventLoopGroup. If the `setEventLoopGroup(value:)` is not called, `nil` in variable `_eventLoopGroup` forces
     /// Server to run in `globalELG` since value of `eventLoopGroup` in `ServerBootstrap(group: eventLoopGroup)` gets initialzed to value `globalELG`
     /// if `setEventLoopGroup(value:)` is not called before `listen()`
+    /// If you are using Kitura-NIO and need to access EventLoopGroup that Kitura uses, you can do so like this:
+    ///
+    ///         ```let eventLoopGroup = server.eventLoopGroup```
+    ///
     public var eventLoopGroup: EventLoopGroup {
         if let value = self._eventLoopGroup { return value }
         let value = globalELG
@@ -306,6 +310,11 @@ public class HTTPServer: Server {
     /// Sets the EventLoopGroup to be used by this HTTPServer. This may be called once
     /// and once only, and must be called prior to `listen()`.
     /// - Throws: If the EventLoopGroup has already been assigned.
+    /// If you are using Kitura-NIO and need to set EventLoopGroup that Kitura uses, you can do so like this:
+    ///
+    ///         ```server.setEventLoopGroup(EventLoopGroup)```
+    ///
+    /// - Parameter : this function is supplied with user defined EventLoopGroup as arguement
     public func setEventLoopGroup(_ value: EventLoopGroup) throws {
         guard _eventLoopGroup == nil else {
             throw HTTPServerError.eventLoopGroupAlreadyInitialized

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -705,13 +705,13 @@ enum KituraWebSocketUpgradeError: Error {
 // HTTP server errors
 public struct HTTPServerError: Error,Equatable {
 
-    internal enum _HTTPServerError: Error {
+    internal enum HTTPServerErrorType: Error {
         case eventLoopGroupAlreadyInitialized
     }
 
-    private var _httpServerError: _HTTPServerError
+    private var _httpServerError: HTTPServerErrorType
 
-    private init(value: _HTTPServerError){
+    private init(value: HTTPServerErrorType){
         self._httpServerError = value
     }
 

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -125,7 +125,7 @@ public class HTTPServer: Server {
     private let maxPendingConnections = 100
 
     /// The event loop group on which the HTTP handler runs
-    public let eventLoopGroup: MultiThreadedEventLoopGroup
+    public let eventLoopGroup: EventLoopGroup
 
     var quiescingHelper: ServerQuiescingHelper?
 
@@ -155,7 +155,7 @@ public class HTTPServer: Server {
         self.options = options
     }
 
-    public init(eventLoopGroup: MultiThreadedEventLoopGroup) {
+    public init(eventLoopGroup: EventLoopGroup) {
         self.eventLoopGroup = eventLoopGroup
     }
 

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -125,7 +125,7 @@ public class HTTPServer: Server {
     private let maxPendingConnections = 100
 
     /// The event loop group on which the HTTP handler runs
-    private let eventLoopGroup: MultiThreadedEventLoopGroup
+    public let eventLoopGroup: MultiThreadedEventLoopGroup
 
     var quiescingHelper: ServerQuiescingHelper?
 
@@ -153,6 +153,10 @@ public class HTTPServer: Server {
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 #endif
         self.options = options
+    }
+
+    public init(eventLoopGroup: MultiThreadedEventLoopGroup) {
+        self.eventLoopGroup = eventLoopGroup
     }
 
     /**

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -91,12 +91,11 @@ public class HTTPServer: Server {
      ````
     */
     public private(set) var state: ServerState {
-	get {
-		    return self.syncQ.sync {
+        get {
+            return self.syncQ.sync {
                 return self._state
             }
         }
-
         set {
             self.syncQ.sync {
                 self._state = newValue
@@ -703,6 +702,18 @@ enum KituraWebSocketUpgradeError: Error {
     case unknownUpgradeError
 }
 
-public enum HTTPServerError: Error {
-    case eventLoopGroupAlreadyInitialized
+// HTTP server errors
+public struct HTTPServerError: Error,Equatable {
+
+    internal enum _HTTPServerError: Error {
+        case eventLoopGroupAlreadyInitialized
+    }
+
+    private var _httpServerError: _HTTPServerError
+
+    private init(value: _HTTPServerError){
+        self._httpServerError = value
+    }
+
+    public static var eventLoopGroupAlreadyInitialized = HTTPServerError(value: .eventLoopGroupAlreadyInitialized)
 }

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -143,7 +143,9 @@ public class HTTPServer: Server {
     /// if `setEventLoopGroup(value:)` is not called before `listen()`
     /// If you are using Kitura-NIO and need to access EventLoopGroup that Kitura uses, you can do so like this:
     ///
-    ///         ```let eventLoopGroup = server.eventLoopGroup```
+    ///         ```swift
+    ///         let eventLoopGroup = server.eventLoopGroup
+    ///         ```
     ///
     public var eventLoopGroup: EventLoopGroup {
         if let value = self._eventLoopGroup { return value }
@@ -312,7 +314,9 @@ public class HTTPServer: Server {
     /// - Throws: If the EventLoopGroup has already been assigned.
     /// If you are using Kitura-NIO and need to set EventLoopGroup that Kitura uses, you can do so like this:
     ///
-    ///         ```server.setEventLoopGroup(EventLoopGroup)```
+    ///         ```swift
+    ///         server.setEventLoopGroup(EventLoopGroup)
+    ///         ```
     ///
     /// - Parameter : this function is supplied with user defined EventLoopGroup as arguement
     public func setEventLoopGroup(_ value: EventLoopGroup) throws {

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -212,7 +212,7 @@ class RegressionTests: KituraNetTest {
             do {
                 try server.listen(on: serverPort)
             } catch {
-               XCTFail("Couldn't start server \(error)")
+               XCTFail("Unable to start the server \(error)")
             }
             var goodClient = try GoodClient()
             /// Connect a 'good' (SSL enabled) client to the server
@@ -234,7 +234,7 @@ class RegressionTests: KituraNetTest {
             do {
                 try server2.listen(on: serverPort2)
             } catch {
-                XCTFail("Couldn't start server \(error)")
+                XCTFail("Unable to start the server \(error)")
             }
             var goodClient2 = try GoodClient()
             /// Connect a 'good' (SSL enabled) client to the server
@@ -246,6 +246,9 @@ class RegressionTests: KituraNetTest {
         waitForExpectations(timeout: 10)
     }
 
+    // Tests eventLoopGroup initialization in server after starting the server
+    // If server `setEventLoopGroup` is called after function `listen()` server should throw
+    // error HTTPServerError.eventLoopGroupAlreadyInitialized
     func testFailEventLoopGroupReinitialization() {
         do {
         #if os(Linux)
@@ -258,7 +261,7 @@ class RegressionTests: KituraNetTest {
         do {
             try server.listen(on: 8093)
         } catch {
-            XCTFail("Couldn't start server \(error)")
+            XCTFail("Unable to start the server \(error)")
             }
         do {
             try server.setEventLoopGroup(eventLoopGroup)

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -23,6 +23,12 @@ import NIOHTTP1
 import NIOSSL
 import LoggerAPI
 
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
 class RegressionTests: KituraNetTest {
 
     static var allTests: [(String, (RegressionTests) -> () throws -> Void)] {

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -33,7 +33,8 @@ class RegressionTests: KituraNetTest {
             ("testServersSharingPort", testServersSharingPort),
             ("testBadRequest", testBadRequest),
             ("testBadRequestFollowingGoodRequest", testBadRequestFollowingGoodRequest),
-            ("testCustomEventLoopGroup", testCustomEventLoopGroup)
+            ("testCustomEventLoopGroup", testCustomEventLoopGroup),
+            ("testFailEventLoopGroupReinitialization", testFailEventLoopGroupReinitialization),
         ]
     }
 
@@ -266,8 +267,8 @@ class RegressionTests: KituraNetTest {
         do {
             try server.setEventLoopGroup(eventLoopGroup)
         } catch {
-            let serverError = error as? HTTPServerError
-            XCTAssertEqual(serverError, HTTPServerError.eventLoopGroupAlreadyInitialized)
+            let httpError = error as? HTTPServerError
+            XCTAssertEqual(httpError, HTTPServerError.eventLoopGroupAlreadyInitialized)
             }
         }
     }

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -194,12 +194,12 @@ class RegressionTests: KituraNetTest {
 
     func testCustomEventLoopGroup() {
         do {
-            #if os(Linux)
+#if os(Linux)
             let numberOfCores = Int(linux_sched_getaffinity())
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: numberOfCores > 0 ? numberOfCores : System.coreCount)
-            #else
+#else
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            #endif
+#endif
             let server = HTTPServer()
             do {
                 try server.setEventLoopGroup(eventLoopGroup)
@@ -216,7 +216,7 @@ class RegressionTests: KituraNetTest {
                XCTFail("Unable to start the server \(error)")
             }
             var goodClient = try GoodClient()
-            /// Connect a 'good' (SSL enabled) client to the server
+            // Connect a 'good' (SSL enabled) client to the server
             try goodClient.connect(serverPort, expectation: self.expectation(description: "Connecting a bad client"))
             XCTAssertEqual(goodClient.connectedPort, serverPort, "GoodClient not connected to expected server port")
 
@@ -238,7 +238,7 @@ class RegressionTests: KituraNetTest {
                 XCTFail("Unable to start the server \(error)")
             }
             var goodClient2 = try GoodClient()
-            /// Connect a 'good' (SSL enabled) client to the server
+            // Connect a 'good' (SSL enabled) client to the server
             try goodClient2.connect(serverPort2, expectation: self.expectation(description: "Connecting a bad client"))
             XCTAssertEqual(goodClient2.connectedPort, serverPort2, "GoodClient not connected to expected server port")
         } catch {
@@ -252,23 +252,23 @@ class RegressionTests: KituraNetTest {
     // error HTTPServerError.eventLoopGroupAlreadyInitialized
     func testFailEventLoopGroupReinitialization() {
         do {
-        #if os(Linux)
-        let numberOfCores = Int(linux_sched_getaffinity())
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: numberOfCores > 0 ? numberOfCores : System.coreCount)
-        #else
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        #endif
-        let server = HTTPServer()
-        do {
-            try server.listen(on: 8093)
-        } catch {
-            XCTFail("Unable to start the server \(error)")
+#if os(Linux)
+            let numberOfCores = Int(linux_sched_getaffinity())
+            let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: numberOfCores > 0 ? numberOfCores : System.coreCount)
+#else
+            let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+#endif
+            let server = HTTPServer()
+            do {
+                try server.listen(on: 8093)
+            } catch {
+                XCTFail("Unable to start the server \(error)")
             }
-        do {
-            try server.setEventLoopGroup(eventLoopGroup)
-        } catch {
-            let httpError = error as? HTTPServerError
-            XCTAssertEqual(httpError, HTTPServerError.eventLoopGroupAlreadyInitialized)
+            do {
+                try server.setEventLoopGroup(eventLoopGroup)
+            } catch {
+                let httpError = error as? HTTPServerError
+                XCTAssertEqual(httpError, HTTPServerError.eventLoopGroupAlreadyInitialized)
             }
         }
     }

--- a/Tests/KituraNetTests/RegressionTests.swift
+++ b/Tests/KituraNetTests/RegressionTests.swift
@@ -22,12 +22,7 @@ import NIO
 import NIOHTTP1
 import NIOSSL
 import LoggerAPI
-
-#if os(Linux)
-import Glibc
-#else
-import Darwin
-#endif
+import CLinuxHelpers
 
 class RegressionTests: KituraNetTest {
 


### PR DESCRIPTION
EventLoopGroup `eventloopGroup` was inacessible in previous versions of
Kitura-NIO. This PR makes `eventLoopGroup` a public api and also provides a way
to start HTTPserver with user created EventLoopGroup.