### PR TITLE
move CLinuxHelpers in Linux target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,29 @@
 
 import PackageDescription
 
+#if os(Linux)
+var targets: [PackageDescription.Target] = [
+    .target(
+        name: "CLinuxHelpers",
+        dependencies: []),
+    .target(
+        name: "KituraNet",
+        dependencies: ["NIO", "NIOFoundationCompat", "NIOHTTP1", "NIOSSL", "SSLService", "LoggerAPI", "NIOWebSocket", "CLinuxHelpers", "NIOConcurrencyHelpers", "NIOExtras"]),
+    .testTarget(
+        name: "KituraNetTests",
+        dependencies: ["KituraNet"])
+]
+#else
+var targets: [PackageDescription.Target] = [
+    .target(
+        name: "KituraNet",
+        dependencies: ["NIO", "NIOFoundationCompat", "NIOHTTP1", "NIOSSL", "SSLService", "LoggerAPI", "NIOWebSocket", "NIOConcurrencyHelpers", "NIOExtras"]),
+    .testTarget(
+        name: "KituraNetTests",
+        dependencies: ["KituraNet"])
+]
+#endif
+
 let package = Package(
     name: "Kitura-NIO",
     products: [

--- a/Sources/KituraNet/HTTP/HTTPServer.swift
+++ b/Sources/KituraNet/HTTP/HTTPServer.swift
@@ -28,6 +28,7 @@ import NIOConcurrencyHelpers
 
 #if os(Linux)
 import Glibc
+import CLinuxHelpers
 #else
 import Darwin
 #endif


### PR DESCRIPTION
I am using Kitura-NIO on iOS, and it no need to use CLinuxHelpers on Mac or iOS
